### PR TITLE
Update default experiments as of 27 May 2025

### DIFF
--- a/extensions/azure/src/dependabot/experiments.ts
+++ b/extensions/azure/src/dependabot/experiments.ts
@@ -33,4 +33,6 @@ export const DEFAULT_EXPERIMENTS: Record<string, string | boolean> = {
   'enable-cooldown-for-maven': true,
   'enable-cooldown-for-gomodules': true,
   'enable-cooldown-metrics-collection': true,
+  'enable-cooldown-for-composer': true,
+  'enable-cooldown-for-gradle': true,
 };


### PR DESCRIPTION
As observed at https://github.com/tinglesoftware/dependabot-azure-devops/actions/runs/15244978529/job/42870249524