### PR TITLE
Remove `abandonUnwantedPullRequests` input

### DIFF
--- a/extensions/azure/README.md
+++ b/extensions/azure/README.md
@@ -56,7 +56,6 @@ Dependabot uses Docker containers, which may take time to install if not already
 |Input|Description|
 |--|--|
 |skipPullRequests|**_Optional_**. Determines whether to skip creation and updating of pull requests. When set to `true` the logic to update the dependencies is executed but the actual Pull Requests are not created/updated. This is useful for debugging. Defaults to `false`.|
-|abandonUnwantedPullRequests|**_Optional_**. Determines whether to abandon unwanted pull requests. Defaults to `false`.|
 |setAutoComplete|**_Optional_**. Determines if the pull requests that dependabot creates should have auto complete set. When set to `true`, pull requests that pass all policies will be merged automatically. Defaults to `false`.|
 |mergeStrategy|**_Optional_**. The merge strategy to use when auto complete is set. Learn more [here](https://learn.microsoft.com/en-us/rest/api/azure/devops/git/pull-requests/update?view=azure-devops-rest-6.0&tabs=HTTP#gitpullrequestmergestrategy). Defaults to `squash`.|
 |autoCompleteIgnoreConfigIds|**_Optional_**. List of any policy configuration Id's which auto-complete should not wait for. Only applies to optional policies. Auto-complete always waits for required (blocking) policies.|

--- a/extensions/azure/src/dependabot/output-processor.ts
+++ b/extensions/azure/src/dependabot/output-processor.ts
@@ -254,8 +254,8 @@ export class DependabotOutputProcessor {
       }
 
       case 'close_pull_request': {
-        if (!this.taskInputs.abandonUnwantedPullRequests) {
-          warning(`Skipping pull request closure as 'abandonUnwantedPullRequests' is set to 'false'`);
+        if (this.taskInputs.skipPullRequests) {
+          warning(`Skipping pull request closure as 'skipPullRequests' is set to 'true'`);
           return true;
         }
 

--- a/extensions/azure/src/task-v2.ts
+++ b/extensions/azure/src/task-v2.ts
@@ -201,8 +201,8 @@ export async function abandonPullRequestsWhereSourceRefIsDeleted(
       pullRequest.properties.find((x) => x.name === DEVOPS_PR_PROPERTY_MICROSOFT_GIT_SOURCE_REF_NAME)?.value,
     );
     if (pullRequestSourceRefName && !existingBranchNames.includes(pullRequestSourceRefName)) {
-      // The source branch for the pull request has been deleted; abandon the pull request (if configured to do so)
-      if (taskInputs.abandonUnwantedPullRequests) {
+      // The source branch for the pull request has been deleted; abandon the pull request (if manipulation is allowed)
+      if (!taskInputs.skipPullRequests) {
         warning(
           `Detected source branch for PR #${pullRequest.id} has been deleted; The pull request will be abandoned`,
         );

--- a/extensions/azure/src/utils/shared-variables.ts
+++ b/extensions/azure/src/utils/shared-variables.ts
@@ -65,8 +65,6 @@ export interface ISharedVariables {
 
   /** Determines whether to skip creating/updating pull requests */
   skipPullRequests: boolean;
-  /** Determines whether to abandon unwanted pull requests */
-  abandonUnwantedPullRequests: boolean;
 
   /** The dependabot-cli go package to use for updates. e.g. github.com/dependabot/cli/cmd/dependabot@latest */
   dependabotCliPackage?: string;
@@ -178,7 +176,6 @@ export default function getSharedVariables(): ISharedVariables {
   // Prepare other variables
   const securityAdvisoriesFile: string | undefined = tl.getInput('securityAdvisoriesFile');
   const skipPullRequests: boolean = tl.getBoolInput('skipPullRequests', false);
-  const abandonUnwantedPullRequests: boolean = tl.getBoolInput('abandonUnwantedPullRequests', true);
 
   const dependabotCliPackage: string | undefined = tl.getInput('dependabotCliPackage');
   const dependabotCliApiUrl: string | undefined = tl.getInput('dependabotCliApiUrl', false);
@@ -225,7 +222,6 @@ export default function getSharedVariables(): ISharedVariables {
     securityAdvisoriesFile,
 
     skipPullRequests,
-    abandonUnwantedPullRequests,
 
     dependabotCliPackage,
     dependabotCliApiUrl,

--- a/extensions/azure/tasks/dependabotV2/task.json
+++ b/extensions/azure/tasks/dependabotV2/task.json
@@ -57,15 +57,6 @@
       "helpMarkDown": "When set to `true` the logic to update the dependencies is executed but the actual Pull Requests are not created/updated. Defaults to `false`."
     },
     {
-      "name": "abandonUnwantedPullRequests",
-      "type": "boolean",
-      "groupName": "pull_requests",
-      "label": "Abandon unwanted pull requests.",
-      "defaultValue": false,
-      "required": false,
-      "helpMarkDown": "When set to `true` pull requests that are no longer needed are closed at the tail end of the execution. Defaults to `false`."
-    },
-    {
       "name": "setAutoComplete",
       "type": "boolean",
       "groupName": "pull_requests",

--- a/extensions/azure/tests/dependabot/output-processor.test.ts
+++ b/extensions/azure/tests/dependabot/output-processor.test.ts
@@ -157,8 +157,8 @@ describe('DependabotOutputProcessor', () => {
       expect(prApproverClient.approvePullRequest).toHaveBeenCalled();
     });
 
-    it('should skip processing "close_pull_request" if "abandonUnwantedPullRequests" is false', async () => {
-      taskInputs.abandonUnwantedPullRequests = false;
+    it('should skip processing "close_pull_request" if "skipPullRequests" is true', async () => {
+      taskInputs.skipPullRequests = true;
 
       const result = await processor.process(update, 'close_pull_request', data);
 
@@ -167,7 +167,7 @@ describe('DependabotOutputProcessor', () => {
     });
 
     it('should fail processing "close_pull_request" if pull request does not exist', async () => {
-      taskInputs.abandonUnwantedPullRequests = true;
+      taskInputs.skipPullRequests = false;
       data = {
         'dependency-names': ['dependency1'],
       };
@@ -179,7 +179,7 @@ describe('DependabotOutputProcessor', () => {
     });
 
     it('should process "close_pull_request"', async () => {
-      taskInputs.abandonUnwantedPullRequests = true;
+      taskInputs.skipPullRequests = false;
       update.job['package-manager'] = 'npm';
       data = {
         'dependency-names': ['dependency1'],

--- a/extensions/azure/tests/task-v2.test.ts
+++ b/extensions/azure/tests/task-v2.test.ts
@@ -30,7 +30,7 @@ describe('abandonPullRequestsWhereSourceRefIsDeleted', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     taskInputs = {
-      abandonUnwantedPullRequests: true,
+      skipPullRequests: false,
     } as ISharedVariables;
     devOpsPrAuthorClient = new AzureDevOpsWebApiClient('https://dev.azure.com/test-org', 'fake-token', true);
     devOpsPrAuthorClient.abandonPullRequest = vi.fn().mockResolvedValue(true);
@@ -65,8 +65,8 @@ describe('abandonPullRequestsWhereSourceRefIsDeleted', () => {
     });
   });
 
-  it('should not abandon pull requests when `abandonUnwantedPullRequests` is false', async () => {
-    taskInputs.abandonUnwantedPullRequests = false;
+  it('should not abandon pull requests when `skipPullRequests` is true', async () => {
+    taskInputs.skipPullRequests = true;
 
     await abandonPullRequestsWhereSourceRefIsDeleted(
       taskInputs,


### PR DESCRIPTION
The `abandonUnwantedPullRequests` input is potentially misleading. In scenarios where users expect pull requests to be abandoned but the input is set to false (default value), the behavior can appear incorrect or unexpected.

Its functionality is already covered by `skipPullRequests`, semantically, which controls whether pull requests are modified at all. Removing this input simplifies configuration and avoids ambiguity.

Additionally, this change aligns the configuration with the updater’s output behavior, improving consistency.