### PR TITLE
Non-zero result from dependabot-cli should result in a failed result

### DIFF
--- a/.changeset/cuddly-rocks-heal.md
+++ b/.changeset/cuddly-rocks-heal.md
@@ -1,0 +1,5 @@
+---
+'extension-azure-devops': patch
+---
+
+Non-zero result from dependabot-cli should result in a failed result

--- a/extensions/azure/src/dependabot/cli.ts
+++ b/extensions/azure/src/dependabot/cli.ts
@@ -143,6 +143,7 @@ export class DependabotCli {
         });
         if (dependabotResultCode != 0) {
           error(`Dependabot failed with exit code ${dependabotResultCode}`);
+          return [{ success: false }];
         }
       }
 

--- a/extensions/azure/src/dependabot/models.ts
+++ b/extensions/azure/src/dependabot/models.ts
@@ -13,6 +13,6 @@ export type IDependabotUpdateOperation = DependabotInput & {
 export type IDependabotUpdateOperationResult = {
   success: boolean;
   error?: Error;
-  output: DependabotOutput;
+  output?: DependabotOutput;
   pr?: number;
 };


### PR DESCRIPTION
This is necessary when there are errors in dependabot-cli such as when the docker containers it started suddenly exit.

Fixes: #1746 