### PR TITLE
Added CLI with command to validate a dependabot configuration file

### DIFF
--- a/.changeset/happy-terms-sip.md
+++ b/.changeset/happy-terms-sip.md
@@ -1,0 +1,6 @@
+---
+'paklo': minor
+'extension-azure-devops': patch
+---
+
+Added CLI with command to validate a dependabot configuration file

--- a/packages/paklo/package.json
+++ b/packages/paklo/package.json
@@ -5,6 +5,9 @@
   "type": "module",
   "private": true,
   "license": "AGPL-3.0-later",
+  "bin": {
+    "paklo": "./dist/cli.js"
+  },
   "exports": {
     "./dependabot": {
       "import": "./dist/dependabot.js",
@@ -32,7 +35,8 @@
     "build": "tsup",
     "lint": "eslint .",
     "test": "vitest",
-    "clean": "rimraf .turbo dist"
+    "clean": "rimraf .turbo dist",
+    "cli": "node dist/cli.js"
   },
   "repository": {
     "type": "git",
@@ -49,6 +53,7 @@
   },
   "homepage": "https://github.com/mburumaxwell/dependabot-azure-devops#readme",
   "dependencies": {
+    "commander": "14.0.0",
     "pino": "9.7.0",
     "pino-pretty": "13.0.0",
     "zod": "3.25.56"

--- a/packages/paklo/src/cli/commands/base.ts
+++ b/packages/paklo/src/cli/commands/base.ts
@@ -1,0 +1,48 @@
+import { type Command, type ErrorOptions } from 'commander';
+import { type ZodType } from 'zod/v4';
+import { logger } from '../logger';
+
+export type HandlerErrorOptions = ErrorOptions & {
+  /** The error message. */
+  message: string;
+};
+
+export type HandlerOptions<T> = {
+  /** The parsed options. */
+  options: T;
+
+  /** The command instance. */
+  command: Command;
+
+  /**
+   * Log an error message and exit the process with the given exit code.
+   * @param options - The error message or error options.
+   */
+  error: (options: string | HandlerErrorOptions) => void;
+};
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export type CreateHandlerOptions<T> = {
+  schema: ZodType<T>;
+  input: Record<string, any>;
+  command: any;
+};
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+export async function handlerOptions<T>({
+  schema,
+  input,
+  command: cmd,
+}: CreateHandlerOptions<T>): Promise<HandlerOptions<T>> {
+  const options = await schema.parseAsync(input);
+  const command = cmd as Command;
+  return {
+    options,
+    command,
+    error: (options) => {
+      const { message, code, exitCode } = typeof options === 'string' ? { message: options } : options;
+      logger.error(message);
+      command.error('', { code, exitCode });
+    },
+  };
+}

--- a/packages/paklo/src/cli/commands/generate.ts
+++ b/packages/paklo/src/cli/commands/generate.ts
@@ -1,0 +1,74 @@
+import { Command } from 'commander';
+import { existsSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import { stdin, stdout } from 'node:process';
+import readline from 'node:readline/promises';
+import { z } from 'zod/v4';
+
+import { parseDependabotConfig, POSSIBLE_CONFIG_FILE_PATHS } from '@/dependabot';
+import { logger } from '../logger';
+import { handlerOptions, type HandlerOptions } from './base';
+
+const schema = z.object({
+  file: z.string().optional(),
+  githubToken: z.string().optional(),
+});
+type Options = z.infer<typeof schema>;
+
+async function handler({ options, error }: HandlerOptions<Options>) {
+  let { file: configPath } = options;
+
+  // if we have no file, attempt to check against known paths
+  if (!configPath) {
+    logger.trace('file not specified searching under known possible paths');
+    for (const fp of POSSIBLE_CONFIG_FILE_PATHS) {
+      if (existsSync(fp)) {
+        configPath = fp;
+        break;
+      }
+    }
+
+    // if we still have no path, throw an exception
+    if (!configPath) {
+      error(`Configuration file not found at possible locations:\n${POSSIBLE_CONFIG_FILE_PATHS.join(',\n')}`);
+      return;
+    }
+  }
+
+  // if the file does not exist, there is nothing to do
+  if (!existsSync(configPath)) {
+    error(`Configuration file '${configPath}' does not exist`);
+    return;
+  }
+
+  // load the file contents and parse
+  logger.info(`Using config file at ${configPath}`);
+  const configContents = await readFile(configPath, 'utf-8');
+  const variables = new Map<string, string>();
+  const rl = readline.createInterface({ input: stdin, output: stdout });
+  async function variableFinder(name: string) {
+    if (variables.has(name)) return variables.get(name);
+    logger.trace(`Asking value for variable named: ${name}`);
+    const value = await rl.question(`Please provide the value for '${name}'`);
+    variables.set(name, value);
+    return value;
+  }
+  rl.close();
+  const config = await parseDependabotConfig({ configContents, configPath, variableFinder });
+  logger.info(
+    `Configuration file valid: ${config.updates.length} update(s) and ${config.registries?.length ?? 'no'} registries.`,
+  );
+  error(`This command is not yet fully implemented`);
+}
+
+export const command = new Command('generate')
+  .description('Generate dependabot job file(s) from a configuration file.')
+  .option(
+    '-f, --file <FILE>',
+    'Configuration file to validate.\nIf not specified, the command will search for one in the current directory.',
+  )
+  .option(
+    '--github-token <GITHUB-TOKEN>',
+    'GitHub token to use for authentication. If not specified, you may get rate limited.',
+  )
+  .action(async (input, command) => await handler(await handlerOptions({ schema, input, command })));

--- a/packages/paklo/src/cli/commands/index.ts
+++ b/packages/paklo/src/cli/commands/index.ts
@@ -1,0 +1,4 @@
+import { command as generate } from './generate';
+import { command as validate } from './validate';
+
+export { generate, validate };

--- a/packages/paklo/src/cli/commands/validate.ts
+++ b/packages/paklo/src/cli/commands/validate.ts
@@ -1,0 +1,63 @@
+import { Command } from 'commander';
+import { existsSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import { z } from 'zod/v4';
+
+import { POSSIBLE_CONFIG_FILE_PATHS, parseDependabotConfig } from '@/dependabot';
+import { logger } from '../logger';
+import { handlerOptions, type HandlerOptions } from './base';
+
+const schema = z.object({
+  file: z.string().optional(),
+});
+type Options = z.infer<typeof schema>;
+
+async function handler({ options, error }: HandlerOptions<Options>) {
+  let { file: configPath } = options;
+
+  // if we have no file, attempt to check against known paths
+  if (!configPath) {
+    logger.trace('file not specified searching under known possible paths');
+    for (const fp of POSSIBLE_CONFIG_FILE_PATHS) {
+      if (existsSync(fp)) {
+        configPath = fp;
+        break;
+      }
+    }
+
+    // if we still have no path, throw an exception
+    if (!configPath) {
+      error(`Configuration file not found at possible locations:\n${POSSIBLE_CONFIG_FILE_PATHS.join(',\n')}`);
+      return;
+    }
+  }
+
+  // if the file does not exist, there is nothing to do
+  if (!existsSync(configPath)) {
+    error(`Configuration file '${configPath}' does not exist`);
+    return;
+  }
+
+  // load the file contents and validate
+  logger.info(`Validating file at ${configPath}`);
+  const configContents = await readFile(configPath, 'utf-8');
+  const variables: string[] = [];
+  function variableFinder(name: string) {
+    variables.push(name);
+    return undefined;
+  }
+  const config = await parseDependabotConfig({ configContents, configPath, variableFinder });
+  logger.info(
+    `Configuration file valid: ${config.updates.length} update(s) and ${config.registries?.length ?? 'no'} registries.`,
+  );
+  if (variables.length) logger.info(`Found replaceable variables/tokens:\n- ${variables.join('\n- ')}`);
+  else logger.info('No replaceable variables/tokens found.');
+}
+
+export const command = new Command('validate')
+  .description('Validate a dependabot configuration file.')
+  .option(
+    '-f, --file <FILE>',
+    'Configuration file to validate.\nIf not specified, the command will search for one in the current directory.',
+  )
+  .action(async (input, command) => await handler(await handlerOptions({ schema, input, command })));

--- a/packages/paklo/src/cli/index.ts
+++ b/packages/paklo/src/cli/index.ts
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+
+import { Command } from 'commander';
+import packageJson from '../../package.json';
+import { generate, validate } from './commands';
+
+const root = new Command();
+
+root.name('paklo').description('CLI too for running E2E dependabot updates locally.');
+root.usage();
+root.version(packageJson.version, '--version');
+root.addCommand(validate);
+root.addCommand(generate);
+
+const args = process.argv;
+root.parse(args);
+
+// If no command is provided, show help
+if (!args.slice(2).length) {
+  root.help();
+}

--- a/packages/paklo/src/cli/logger.ts
+++ b/packages/paklo/src/cli/logger.ts
@@ -1,0 +1,6 @@
+// this file exists in its simplicity because we may need to edit
+// some settings in the logger we use for the CLI later on
+
+import { logger } from '@/logger';
+
+export { logger };

--- a/packages/paklo/src/dependabot/config.test.ts
+++ b/packages/paklo/src/dependabot/config.test.ts
@@ -85,7 +85,7 @@ describe('Parse registries', () => {
     const config = await DependabotConfigSchema.parseAsync(
       yaml.load(await readFile('fixtures/config/sample-registries.yml', 'utf-8')),
     );
-    const registries = parseRegistries(config, () => undefined);
+    const registries = await parseRegistries(config, () => undefined);
     expect(Object.keys(registries).length).toBe(11);
 
     // composer-repository

--- a/packages/paklo/src/dependabot/job-builder.test.ts
+++ b/packages/paklo/src/dependabot/job-builder.test.ts
@@ -11,7 +11,7 @@ describe('makeCredentialsMetadata', () => {
       yaml.load(await readFile('fixtures/config/sample-registries.yml', 'utf-8')),
     );
 
-    let registries = parseRegistries(config, () => undefined);
+    let registries = await parseRegistries(config, () => undefined);
     expect(Object.keys(registries).length).toBe(11);
 
     // TODO: change this to call makeCredentials/mapCredentials once it is moved to this package hence remove this hack

--- a/packages/paklo/src/dependabot/placeholder.ts
+++ b/packages/paklo/src/dependabot/placeholder.ts
@@ -1,12 +1,12 @@
-export type VariableFinderFn = (name: string) => string | undefined;
+export type VariableFinderFn = (name: string) => string | undefined | Promise<string | undefined>;
 
-function convertPlaceholder({
+async function convertPlaceholder({
   input,
   variableFinder,
 }: {
   input?: string;
   variableFinder: VariableFinderFn;
-}): string | undefined {
+}): Promise<string | undefined> {
   if (!input) return undefined;
 
   const matches: RegExpExecArray[] = extractPlaceholder(input);
@@ -14,7 +14,7 @@ function convertPlaceholder({
   for (const match of matches) {
     const placeholder = match[0];
     const name = match[1]!;
-    const value = variableFinder(name) ?? placeholder;
+    const value = (await variableFinder(name)) ?? placeholder;
     result = result.replace(placeholder, value);
   }
   return result;

--- a/packages/paklo/src/logger.ts
+++ b/packages/paklo/src/logger.ts
@@ -1,6 +1,7 @@
 import { pino, type DestinationStream, type Logger, type LoggerOptions } from 'pino';
 import { PinoPretty } from 'pino-pretty';
-import { environment } from './environment';
+
+import { environment } from '@/environment';
 
 const options: LoggerOptions = {
   level: process.env.LOG_LEVEL || (environment.production ? 'warn' : 'debug'),
@@ -21,10 +22,10 @@ const destination: DestinationStream | undefined = environment.production
       // https://github.com/pinojs/pino-pretty#usage-with-jest
       sync: environment.test,
     });
-const logger = pino(options, destination);
+export const logger = pino(options, destination);
 
 /** Options for creating a logger. */
-type CreateOptions = {
+export type CreateOptions = {
   /**
    * The name of the application.
    * @example `website`
@@ -34,8 +35,8 @@ type CreateOptions = {
 
 /**
  * Creates a logger for the application.
- * @param {CreateOptions} options - The options for creating the logger.
- * @returns {Logger} The created logger.
+ * @param options - The options for creating the logger.
+ * @returns The created logger.
  */
 export function create({ name }: CreateOptions): Logger {
   const application = `paklo-${name}`;

--- a/packages/paklo/tsconfig.json
+++ b/packages/paklo/tsconfig.json
@@ -1,6 +1,12 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
   "include": ["./src"],
   "exclude": ["dist", "build", "node_modules"]
 }

--- a/packages/paklo/tsup.config.ts
+++ b/packages/paklo/tsup.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
     dependabot: 'src/dependabot/index.ts',
     environment: 'src/environment/index.ts',
     logger: 'src/logger.ts',
+    cli: 'src/cli/index.ts',
   },
   outDir: 'dist',
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -172,6 +172,9 @@ importers:
 
   packages/paklo:
     dependencies:
+      commander:
+        specifier: 14.0.0
+        version: 14.0.0
       pino:
         specifier: 9.7.0
         version: 9.7.0
@@ -1943,6 +1946,10 @@ packages:
 
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
+
+  commander@14.0.0:
+    resolution: {integrity: sha512-2uM9rYjPvyq39NwLRqaiLtWHyDC1FvryJDa2ATTVims5YAS4PupsEQsDvP14FqhFr0P49CYDugi59xaxJlTXRA==}
+    engines: {node: '>=20'}
 
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
@@ -6299,6 +6306,8 @@ snapshots:
       delayed-stream: 1.0.0
 
   comma-separated-tokens@2.0.3: {}
+
+  commander@14.0.0: {}
 
   commander@4.1.1: {}
 


### PR DESCRIPTION
Introduces a new CLI with a command that can validate a Dependabot configuration file. This can help ensure the config is well-formed and adheres to expected structure before it's committed or used.

The CLI is being added a simple solution that one can use to automate in different workflows. It is aimed at anyone running outside Azure Pipelines (e.g. on a Raspberry PI) or scenarios where people used the earlier docker images to run updates.

This CLI might also end up replacing the use of [`dependabot-cli`](https://github.com/dependabot/cli) with direct usage of docker as is done in [`dependabot-action`](https://github.com/github/dependabot-action).

> The `generate` command present at this time is not yet fully functional. That will happen in a followup PR/commit