### PR TITLE
Do not write YAML files with refs

### DIFF
--- a/.changeset/rich-dolls-bow.md
+++ b/.changeset/rich-dolls-bow.md
@@ -1,0 +1,5 @@
+---
+'extension-azure-devops': patch
+---
+
+Do not write YAML files with refs

--- a/extensions/azure/src/dependabot/cli.ts
+++ b/extensions/azure/src/dependabot/cli.ts
@@ -243,10 +243,13 @@ export class DependabotCli {
 // Documentation on the job model can be found here:
 // https://github.com/dependabot/cli/blob/main/internal/model/job.go
 async function writeJobConfigFile(path: string, input: DependabotInput): Promise<void> {
-  const contents = yaml.dump({
-    job: input.job,
-    credentials: input.credentials,
-  });
+  const contents = yaml.dump(
+    {
+      job: input.job,
+      credentials: input.credentials,
+    },
+    { noRefs: true /* Dereference objects that may be repeated */ },
+  );
   debug(`JobConfig:\r\n${contents}`);
   await writeFile(path, contents);
 }


### PR DESCRIPTION
With reuse of objects, refs are used in YAML but dependabot-cli does not yet suport them. Setting `noRefs: true` when writing YAML files.