### PR TITLE
Include project in usage telemetry

### DIFF
--- a/.changeset/slimy-crabs-yell.md
+++ b/.changeset/slimy-crabs-yell.md
@@ -1,0 +1,5 @@
+---
+"@paklo/cli": patch
+---
+
+Include project in usage telemetry

--- a/apps/dashboard/prisma/migrations/20251021095537_usage_telemetry_project/migration.sql
+++ b/apps/dashboard/prisma/migrations/20251021095537_usage_telemetry_project/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "usage_telemetry" ADD COLUMN     "project" VARCHAR(512);

--- a/apps/dashboard/prisma/schema.prisma
+++ b/apps/dashboard/prisma/schema.prisma
@@ -45,6 +45,7 @@ model UsageTelemetry {
   trigger         JobTrigger
   provider        SourceProvider
   owner           String          @db.VarChar(250)
+  project         String?         @db.VarChar(512) // TODO: remove nullable after older records are cleared (90 days after 2025-Oct-21 i.e. 2026-Jan-19)
   packageManager  String          @db.VarChar(50)
   started         DateTime
   duration        Int

--- a/apps/dashboard/src/app/api/usage-telemetry/route.ts
+++ b/apps/dashboard/src/app/api/usage-telemetry/route.ts
@@ -29,6 +29,7 @@ app.post('/', zValidator('json', UsageTelemetryRequestDataSchema), async (contex
     version: payload.version,
     provider: payload.provider,
     owner: payload.owner,
+    project: payload.project ?? null,
     packageManager: payload['package-manager'],
     started: payload.started,
     duration: payload.duration,

--- a/packages/paklo/src/azure/jobs-runner.ts
+++ b/packages/paklo/src/azure/jobs-runner.ts
@@ -214,6 +214,7 @@ export class AzureLocalJobsRunner extends LocalJobsRunner {
         trigger: 'user',
         provider: job.source.provider,
         owner: url.url.toString(),
+        project: `${url.url.toString().replace(/\/$/, '')}/${url.project}`,
         'package-manager': job['package-manager'],
       };
     }

--- a/packages/paklo/src/dependabot/job-runner.ts
+++ b/packages/paklo/src/dependabot/job-runner.ts
@@ -95,7 +95,7 @@ export class JobRunner {
 }
 
 export type RunJobOptions = JobRunnerOptions & {
-  usage: Pick<UsageTelemetryRequestData, 'trigger' | 'provider' | 'owner' | 'package-manager'>;
+  usage: Pick<UsageTelemetryRequestData, 'trigger' | 'provider' | 'owner' | 'project' | 'package-manager'>;
 };
 export type RunJobResult = { success: true; message?: string } | { success: false; message: string };
 

--- a/packages/paklo/src/dependabot/usage.ts
+++ b/packages/paklo/src/dependabot/usage.ts
@@ -34,6 +34,7 @@ export const UsageTelemetryRequestDataSchema = z.object({
   trigger: z.enum(['user', 'service']),
   provider: DependabotSourceProviderSchema,
   owner: z.url(),
+  project: z.url().optional(), // was added later hence optional for backward compatibility
   'package-manager': DependabotPackageManagerSchema,
   id: z.number(), // job identifier, for correlation
   started: z.coerce.date(),


### PR DESCRIPTION
Adds project tracking to disambiguate analytics for owners with multiple projects. This granularity is essential for identifying usage patterns, optimising for high-traffic projects, and providing better support.