### PR TITLE
Make use of `octokit-js` instead of rolling own

### DIFF
--- a/.changeset/many-ears-heal.md
+++ b/.changeset/many-ears-heal.md
@@ -1,0 +1,6 @@
+---
+"@paklo/runner": patch
+"@paklo/core": minor
+---
+
+Make use of [`octokit-js`](https://github.com/octokit/octokit.js) instead of rolling own

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -66,6 +66,7 @@
     "lucide-react": "0.552.0",
     "next": "16.0.1",
     "next-themes": "0.4.6",
+    "octokit": "5.0.5",
     "react": "19.2.0",
     "react-dom": "19.2.0",
     "react-timeago": "8.3.0",

--- a/apps/web/src/actions/organizations/validate-github-token.test.ts
+++ b/apps/web/src/actions/organizations/validate-github-token.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { validateGitHubToken } from './validate-github-token';
+
+describe('validateGitHubToken', () => {
+  it('returns invalid for empty token', async () => {
+    const result = await validateGitHubToken({ token: '' });
+    expect(result.valid).toBe(false);
+    expect(result.message).toBe('Token is required');
+  });
+
+  // when testing the real thing, remove .skip and provide a valid token
+  describe.skip('real API (ONLY FOR LOCAL USE)', async () => {
+    it('returns invalid for malformed token', async () => {
+      const result = await validateGitHubToken({ token: 'malformed_token' });
+      expect(result.valid).toBe(false);
+      expect(result.message).toBe('Invalid token. Please check your GitHub personal access token.');
+    }, 2000);
+
+    const token = 'YOUR_GITHUB_TOKEN_HERE';
+
+    it('works with a real token', async () => {
+      const result = await validateGitHubToken({ token });
+      expect(result.valid).toBe(true);
+      expect(result.message).toBeUndefined();
+    }, 2000);
+  });
+});

--- a/apps/web/src/actions/organizations/validate-github-token.ts
+++ b/apps/web/src/actions/organizations/validate-github-token.ts
@@ -1,7 +1,58 @@
 'use server';
 
+import { createGitHubClient } from '@paklo/core/github';
+
 export async function validateGitHubToken({ token }: { token: string }): Promise<{ valid: boolean; message?: string }> {
-  // TODO: implement GitHub token validation logic here
-  new Promise((resolve) => setTimeout(resolve, 2000));
+  if (!token || token.trim().length === 0) {
+    return { valid: false, message: 'Token is required' };
+  }
+
+  try {
+    const octokit = createGitHubClient({ token });
+
+    // Test the token by fetching the authenticated user's information
+    const { status } = await octokit.rest.users.getAuthenticated();
+    if (status < 200 || status >= 300) {
+      return { valid: false, message: 'Unknown error occurred while validating the token.' };
+    }
+
+    // Check if the token has the required 'repo' scope
+    // We can infer this by trying to access a repository-specific endpoint
+    try {
+      await octokit.rest.repos.listForAuthenticatedUser({
+        per_page: 1,
+        type: 'all',
+      });
+    } catch (error) {
+      // If we can get user info but not repos, the token might not have repo scope
+      if (error instanceof Error && error.message.includes('403')) {
+        return {
+          valid: false,
+          message:
+            'Token is valid but missing required "repo" scope. Please ensure your token has repository access permissions.',
+        };
+      }
+    }
+  } catch (error) {
+    if (error instanceof Error) {
+      // Check for common error scenarios
+      if (error.message.includes('401') || error.message.includes('Bad credentials')) {
+        return { valid: false, message: 'Invalid token. Please check your GitHub personal access token.' };
+      }
+      if (error.message.includes('403')) {
+        return {
+          valid: false,
+          message: 'Token has insufficient permissions. Please ensure it has the required scopes.',
+        };
+      }
+      if (error.message.includes('rate limit')) {
+        return { valid: false, message: 'Rate limit exceeded. Please try again later.' };
+      }
+      return { valid: false, message: `Token validation failed: ${error.message}` };
+    }
+
+    return { valid: false, message: 'An unexpected error occurred while validating the token.' };
+  }
+
   return { valid: true };
 }

--- a/bruno/.env.sample
+++ b/bruno/.env.sample
@@ -5,3 +5,4 @@
 # Copy this to .env and populate the values
 
 AZURE_DEVOPS_PAT="<your-token-here>"
+GITHUB_TOKEN="<your-github-token-here>"

--- a/bruno/environments/github.bru
+++ b/bruno/environments/github.bru
@@ -1,0 +1,3 @@
+vars {
+  GITHUB_TOKEN: {{process.env.GITHUB_TOKEN}}
+}

--- a/bruno/ghsa-security-vulnerabilities.bru
+++ b/bruno/ghsa-security-vulnerabilities.bru
@@ -1,0 +1,66 @@
+meta {
+  name: ghsa-security-vulnerabilities
+  type: http
+  seq: 2
+}
+
+post {
+  url: https://api.github.com/graphql
+  body: graphql
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{GITHUB_TOKEN}}
+}
+
+body:graphql {
+  query($ecosystem: SecurityAdvisoryEcosystem, $package: String) {
+    securityVulnerabilities(first: 100, ecosystem: $ecosystem, package: $package) {
+      nodes {
+        advisory {
+          identifiers {
+            type,
+            value
+          },
+          severity,
+          summary,
+          description,
+          references {
+            url
+          }
+          cvss {
+            score
+            vectorString
+          }
+          epss {
+            percentage
+            percentile
+          }
+          cwes (first: 100) {
+            nodes {
+              cweId
+              name
+              description
+            }
+          }
+          publishedAt
+          updatedAt
+          withdrawnAt
+          permalink
+        }
+        vulnerableVersionRange
+        firstPatchedVersion {
+          identifier
+        }
+      }
+    }
+  }
+}
+
+body:graphql:vars {
+  {
+    "ecosystem": "NPM",
+    "package": "lodash"
+  }
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -71,6 +71,7 @@
     "@hono/zod-validator": "0.7.4",
     "hono": "4.10.4",
     "js-yaml": "4.1.0",
+    "octokit": "5.0.5",
     "pino": "10.1.0",
     "pino-pretty": "13.1.2",
     "semver": "7.7.3",

--- a/packages/core/src/github/client.ts
+++ b/packages/core/src/github/client.ts
@@ -1,0 +1,8 @@
+import { Octokit } from 'octokit';
+
+export function createGitHubClient({ token }: { token: string }): Octokit {
+  return new Octokit({
+    auth: token,
+    // could add retry here perhaps?
+  });
+}

--- a/packages/core/src/github/ghsa.test.ts
+++ b/packages/core/src/github/ghsa.test.ts
@@ -1,7 +1,7 @@
 import { readFile } from 'node:fs/promises';
 import { describe, expect, it } from 'vitest';
 
-import { SecurityVulnerabilitySchema } from './ghsa';
+import { GitHubSecurityAdvisoryClient, SecurityVulnerabilitySchema } from './ghsa';
 
 describe('SecurityVulnerabilitySchema', () => {
   it('works for sample', async () => {
@@ -16,4 +16,25 @@ describe('SecurityVulnerabilitySchema', () => {
     expect(value.vulnerableVersionRange).toBe('< 3.0.1');
     expect(value.firstPatchedVersion).toStrictEqual({ identifier: '3.0.1' });
   });
+
+  // when testing the real thing, remove .skip and provide a valid token
+  it.skip('real API (ONLY FOR LOCAL USE)', async () => {
+    const client = new GitHubSecurityAdvisoryClient('YOUR_GITHUB_TOKEN_HERE');
+
+    // Test with a small package that's likely to have vulnerabilities
+    const vulnerabilities = await client.getSecurityVulnerabilitiesAsync('NPM', [
+      { name: 'lodash', version: '4.0.0' }, // Old version likely to have known vulnerabilities
+    ]);
+
+    console.log('Found vulnerabilities:', vulnerabilities.length);
+    if (vulnerabilities.length > 0) {
+      console.log('First vulnerability:', vulnerabilities[0]);
+    }
+
+    // Basic assertions
+    expect(vulnerabilities).toBeDefined();
+    expect(Array.isArray(vulnerabilities)).toBe(true);
+    expect(vulnerabilities.length).toBeGreaterThan(1);
+    expect(vulnerabilities[0]!.advisory.permalink).toEqual('https://github.com/advisories/GHSA-29mw-wpgm-hmr9');
+  }, 2000);
 });

--- a/packages/core/src/github/index.ts
+++ b/packages/core/src/github/index.ts
@@ -1,1 +1,2 @@
+export * from './client';
 export * from './ghsa';

--- a/packages/runner/src/local/azure/runner.test.ts
+++ b/packages/runner/src/local/azure/runner.test.ts
@@ -9,7 +9,7 @@ import {
   type IPullRequestProperties,
 } from '@paklo/core/azure';
 import { DEFAULT_EXPERIMENTS, type DependabotConfig, type DependabotUpdate } from '@paklo/core/dependabot';
-import { GitHubGraphClient } from '@paklo/core/github';
+import { GitHubSecurityAdvisoryClient } from '@paklo/core/github';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { SecretMasker } from '../../api-client';
 import { runJob } from '../../run';
@@ -17,7 +17,7 @@ import { AzureLocalJobsRunner, type AzureLocalJobsRunnerOptions } from './runner
 import { AzureLocalDependabotServer } from './server';
 
 vi.mock('@paklo/core/github', () => ({
-  GitHubGraphClient: vi.fn(),
+  GitHubSecurityAdvisoryClient: vi.fn(),
   filterVulnerabilities: vi.fn((vulns) => vulns || []),
   getGhsaPackageEcosystemFromDependabotPackageManager: vi.fn(() => 'npm'),
 }));
@@ -286,11 +286,11 @@ describe('AzureLocalJobsRunner', () => {
       options.config.updates[0]!['open-pull-requests-limit'] = 0;
       options.githubToken = 'fake-github-token';
 
-      // Mock GitHubGraphClient properly
+      // Mock GitHubSecurityAdvisoryClient properly
       const mockGhsaClient = {
         getSecurityVulnerabilitiesAsync: vi.fn().mockResolvedValue([]),
       };
-      vi.mocked(GitHubGraphClient).mockImplementation(function MockGitHubGraphClient() {
+      vi.mocked(GitHubSecurityAdvisoryClient).mockImplementation(function MockGitHubSecurityAdvisoryClient() {
         return mockGhsaClient as any;
       } as any);
 
@@ -398,11 +398,11 @@ describe('AzureLocalJobsRunner', () => {
       options.config.updates[0]!['open-pull-requests-limit'] = 0;
       options.securityAdvisoriesFile = '/path/to/advisories.json';
 
-      // Mock GitHubGraphClient
+      // Mock GitHubSecurityAdvisoryClient
       const mockGhsaClient = {
         getSecurityVulnerabilitiesAsync: vi.fn().mockResolvedValue([]),
       };
-      vi.mocked(GitHubGraphClient).mockImplementation(function MockGitHubGraphClient() {
+      vi.mocked(GitHubSecurityAdvisoryClient).mockImplementation(function MockGitHubSecurityAdvisoryClient() {
         return mockGhsaClient as any;
       } as any);
 

--- a/packages/runner/src/local/azure/runner.ts
+++ b/packages/runner/src/local/azure/runner.ts
@@ -16,7 +16,7 @@ import {
 } from '@paklo/core/dependabot';
 import {
   filterVulnerabilities,
-  GitHubGraphClient,
+  GitHubSecurityAdvisoryClient,
   getGhsaPackageEcosystemFromDependabotPackageManager,
   type Package,
   type SecurityVulnerability,
@@ -309,7 +309,7 @@ export class AzureLocalJobsRunner extends LocalJobsRunner {
             }
           }
           if (githubToken) {
-            const ghsaClient = new GitHubGraphClient(githubToken);
+            const ghsaClient = new GitHubSecurityAdvisoryClient(githubToken);
             const githubVulnerabilities = await ghsaClient.getSecurityVulnerabilitiesAsync(
               getGhsaPackageEcosystemFromDependabotPackageManager(packageManager),
               packagesToCheckForVulnerabilities || [],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -158,6 +158,9 @@ importers:
       next-themes:
         specifier: 0.4.6
         version: 0.4.6(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      octokit:
+        specifier: 5.0.5
+        version: 5.0.5
       react:
         specifier: 19.2.0
         version: 19.2.0
@@ -308,6 +311,9 @@ importers:
       js-yaml:
         specifier: 4.1.0
         version: 4.1.0
+      octokit:
+        specifier: 5.0.5
+        version: 5.0.5
       pino:
         specifier: 10.1.0
         version: 10.1.0
@@ -1663,6 +1669,113 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
+  '@octokit/app@16.1.2':
+    resolution: {integrity: sha512-8j7sEpUYVj18dxvh0KWj6W/l6uAiVRBl1JBDVRqH1VHKAO/G5eRVl4yEoYACjakWers1DjUkcCHyJNQK47JqyQ==}
+    engines: {node: '>= 20'}
+
+  '@octokit/auth-app@8.1.2':
+    resolution: {integrity: sha512-db8VO0PqXxfzI6GdjtgEFHY9tzqUql5xMFXYA12juq8TeTgPAuiiP3zid4h50lwlIP457p5+56PnJOgd2GGBuw==}
+    engines: {node: '>= 20'}
+
+  '@octokit/auth-oauth-app@9.0.3':
+    resolution: {integrity: sha512-+yoFQquaF8OxJSxTb7rnytBIC2ZLbLqA/yb71I4ZXT9+Slw4TziV9j/kyGhUFRRTF2+7WlnIWsePZCWHs+OGjg==}
+    engines: {node: '>= 20'}
+
+  '@octokit/auth-oauth-device@8.0.3':
+    resolution: {integrity: sha512-zh2W0mKKMh/VWZhSqlaCzY7qFyrgd9oTWmTmHaXnHNeQRCZr/CXy2jCgHo4e4dJVTiuxP5dLa0YM5p5QVhJHbw==}
+    engines: {node: '>= 20'}
+
+  '@octokit/auth-oauth-user@6.0.2':
+    resolution: {integrity: sha512-qLoPPc6E6GJoz3XeDG/pnDhJpTkODTGG4kY0/Py154i/I003O9NazkrwJwRuzgCalhzyIeWQ+6MDvkUmKXjg/A==}
+    engines: {node: '>= 20'}
+
+  '@octokit/auth-token@6.0.0':
+    resolution: {integrity: sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==}
+    engines: {node: '>= 20'}
+
+  '@octokit/auth-unauthenticated@7.0.3':
+    resolution: {integrity: sha512-8Jb1mtUdmBHL7lGmop9mU9ArMRUTRhg8vp0T1VtZ4yd9vEm3zcLwmjQkhNEduKawOOORie61xhtYIhTDN+ZQ3g==}
+    engines: {node: '>= 20'}
+
+  '@octokit/core@7.0.6':
+    resolution: {integrity: sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==}
+    engines: {node: '>= 20'}
+
+  '@octokit/endpoint@11.0.2':
+    resolution: {integrity: sha512-4zCpzP1fWc7QlqunZ5bSEjxc6yLAlRTnDwKtgXfcI/FxxGoqedDG8V2+xJ60bV2kODqcGB+nATdtap/XYq2NZQ==}
+    engines: {node: '>= 20'}
+
+  '@octokit/graphql@9.0.3':
+    resolution: {integrity: sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==}
+    engines: {node: '>= 20'}
+
+  '@octokit/oauth-app@8.0.3':
+    resolution: {integrity: sha512-jnAjvTsPepyUaMu9e69hYBuozEPgYqP4Z3UnpmvoIzHDpf8EXDGvTY1l1jK0RsZ194oRd+k6Hm13oRU8EoDFwg==}
+    engines: {node: '>= 20'}
+
+  '@octokit/oauth-authorization-url@8.0.0':
+    resolution: {integrity: sha512-7QoLPRh/ssEA/HuHBHdVdSgF8xNLz/Bc5m9fZkArJE5bb6NmVkDm3anKxXPmN1zh6b5WKZPRr3697xKT/yM3qQ==}
+    engines: {node: '>= 20'}
+
+  '@octokit/oauth-methods@6.0.2':
+    resolution: {integrity: sha512-HiNOO3MqLxlt5Da5bZbLV8Zarnphi4y9XehrbaFMkcoJ+FL7sMxH/UlUsCVxpddVu4qvNDrBdaTVE2o4ITK8ng==}
+    engines: {node: '>= 20'}
+
+  '@octokit/openapi-types@27.0.0':
+    resolution: {integrity: sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==}
+
+  '@octokit/openapi-webhooks-types@12.0.3':
+    resolution: {integrity: sha512-90MF5LVHjBedwoHyJsgmaFhEN1uzXyBDRLEBe7jlTYx/fEhPAk3P3DAJsfZwC54m8hAIryosJOL+UuZHB3K3yA==}
+
+  '@octokit/plugin-paginate-graphql@6.0.0':
+    resolution: {integrity: sha512-crfpnIoFiBtRkvPqOyLOsw12XsveYuY2ieP6uYDosoUegBJpSVxGwut9sxUgFFcll3VTOTqpUf8yGd8x1OmAkQ==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': '>=6'
+
+  '@octokit/plugin-paginate-rest@14.0.0':
+    resolution: {integrity: sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': '>=6'
+
+  '@octokit/plugin-rest-endpoint-methods@17.0.0':
+    resolution: {integrity: sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': '>=6'
+
+  '@octokit/plugin-retry@8.0.3':
+    resolution: {integrity: sha512-vKGx1i3MC0za53IzYBSBXcrhmd+daQDzuZfYDd52X5S0M2otf3kVZTVP8bLA3EkU0lTvd1WEC2OlNNa4G+dohA==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': '>=7'
+
+  '@octokit/plugin-throttling@11.0.3':
+    resolution: {integrity: sha512-34eE0RkFCKycLl2D2kq7W+LovheM/ex3AwZCYN8udpi6bxsyjZidb2McXs69hZhLmJlDqTSP8cH+jSRpiaijBg==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': ^7.0.0
+
+  '@octokit/request-error@7.0.2':
+    resolution: {integrity: sha512-U8piOROoQQUyExw5c6dTkU3GKxts5/ERRThIauNL7yaRoeXW0q/5bgHWT7JfWBw1UyrbK8ERId2wVkcB32n0uQ==}
+    engines: {node: '>= 20'}
+
+  '@octokit/request@10.0.6':
+    resolution: {integrity: sha512-FO+UgZCUu+pPnZAR+iKdUt64kPE7QW7ciqpldaMXaNzixz5Jld8dJ31LAUewk0cfSRkNSRKyqG438ba9c/qDlQ==}
+    engines: {node: '>= 20'}
+
+  '@octokit/types@16.0.0':
+    resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
+
+  '@octokit/webhooks-methods@6.0.0':
+    resolution: {integrity: sha512-MFlzzoDJVw/GcbfzVC1RLR36QqkTLUf79vLVO3D+xn7r0QgxnFoLZgtrzxiQErAjFUOdH6fas2KeQJ1yr/qaXQ==}
+    engines: {node: '>= 20'}
+
+  '@octokit/webhooks@14.1.3':
+    resolution: {integrity: sha512-gcK4FNaROM9NjA0mvyfXl0KPusk7a1BeA8ITlYEZVQCXF5gcETTd4yhAU0Kjzd8mXwYHppzJBWgdBVpIR9wUcQ==}
+    engines: {node: '>= 20'}
+
   '@open-draft/deferred-promise@2.2.0':
     resolution: {integrity: sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==}
 
@@ -2865,6 +2978,9 @@ packages:
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
+  '@types/aws-lambda@8.10.157':
+    resolution: {integrity: sha512-ofjcRCO1N7tMZDSO11u5bFHPDfUFD3Q9YK9g4S4w8UDKuG3CNlw2lNK1sd3Itdo7JORygZmG4h9ZykS8dlXvMA==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
@@ -3391,6 +3507,9 @@ packages:
   bcrypt-pbkdf@1.0.2:
     resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
 
+  before-after-hook@4.0.0:
+    resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
+
   better-auth@1.3.34:
     resolution: {integrity: sha512-LWA52SlvnUBJRbN8VLSTLILPomZY3zZAiLxVJCeSQ5uVmaIKkMBhERitkfJcXB9RJcfl4uP+3EqKkb6hX1/uiw==}
     peerDependencies:
@@ -3446,6 +3565,9 @@ packages:
 
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+
+  bottleneck@2.19.5:
+    resolution: {integrity: sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==}
 
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
@@ -4225,6 +4347,9 @@ packages:
   fast-check@3.23.2:
     resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
     engines: {node: '>=8.0.0'}
+
+  fast-content-type-parse@3.0.0:
+    resolution: {integrity: sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==}
 
   fast-copy@3.0.2:
     resolution: {integrity: sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ==}
@@ -5644,6 +5769,10 @@ packages:
     resolution: {integrity: sha512-qkHIGe4q0lSYMv0XI4SsBTJz3WaURhLvd0lKSgtVuOsJ2krg4SgMw3PIRQFMp07yi++UR3se2mkcLqsBNpBb/A==}
     engines: {node: '>= 0.8'}
 
+  octokit@5.0.5:
+    resolution: {integrity: sha512-4+/OFSqOjoyULo7eN7EA97DE0Xydj/PW5aIckxqQIoFjFwqXKuFCvXUJObyJfBF9Khu4RL/jlDRI9FPaMGfPnw==}
+    engines: {node: '>= 20'}
+
   ohash@2.0.11:
     resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
 
@@ -6821,6 +6950,10 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  toad-cache@3.7.0:
+    resolution: {integrity: sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==}
+    engines: {node: '>=12'}
+
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
@@ -7042,6 +7175,12 @@ packages:
 
   unist-util-visit@5.0.0:
     resolution: {integrity: sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==}
+
+  universal-github-app-jwt@2.2.2:
+    resolution: {integrity: sha512-dcmbeSrOdTnsjGjUfAlqNDJrhxXizjAz94ija9Qw8YkZ1uu0d+GoZzyH+Jb9tIIqvGsadUfwg+22k5aDqqwzbw==}
+
+  universal-user-agent@7.0.3:
+    resolution: {integrity: sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==}
 
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
@@ -8675,6 +8814,153 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
+  '@octokit/app@16.1.2':
+    dependencies:
+      '@octokit/auth-app': 8.1.2
+      '@octokit/auth-unauthenticated': 7.0.3
+      '@octokit/core': 7.0.6
+      '@octokit/oauth-app': 8.0.3
+      '@octokit/plugin-paginate-rest': 14.0.0(@octokit/core@7.0.6)
+      '@octokit/types': 16.0.0
+      '@octokit/webhooks': 14.1.3
+
+  '@octokit/auth-app@8.1.2':
+    dependencies:
+      '@octokit/auth-oauth-app': 9.0.3
+      '@octokit/auth-oauth-user': 6.0.2
+      '@octokit/request': 10.0.6
+      '@octokit/request-error': 7.0.2
+      '@octokit/types': 16.0.0
+      toad-cache: 3.7.0
+      universal-github-app-jwt: 2.2.2
+      universal-user-agent: 7.0.3
+
+  '@octokit/auth-oauth-app@9.0.3':
+    dependencies:
+      '@octokit/auth-oauth-device': 8.0.3
+      '@octokit/auth-oauth-user': 6.0.2
+      '@octokit/request': 10.0.6
+      '@octokit/types': 16.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/auth-oauth-device@8.0.3':
+    dependencies:
+      '@octokit/oauth-methods': 6.0.2
+      '@octokit/request': 10.0.6
+      '@octokit/types': 16.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/auth-oauth-user@6.0.2':
+    dependencies:
+      '@octokit/auth-oauth-device': 8.0.3
+      '@octokit/oauth-methods': 6.0.2
+      '@octokit/request': 10.0.6
+      '@octokit/types': 16.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/auth-token@6.0.0': {}
+
+  '@octokit/auth-unauthenticated@7.0.3':
+    dependencies:
+      '@octokit/request-error': 7.0.2
+      '@octokit/types': 16.0.0
+
+  '@octokit/core@7.0.6':
+    dependencies:
+      '@octokit/auth-token': 6.0.0
+      '@octokit/graphql': 9.0.3
+      '@octokit/request': 10.0.6
+      '@octokit/request-error': 7.0.2
+      '@octokit/types': 16.0.0
+      before-after-hook: 4.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/endpoint@11.0.2':
+    dependencies:
+      '@octokit/types': 16.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/graphql@9.0.3':
+    dependencies:
+      '@octokit/request': 10.0.6
+      '@octokit/types': 16.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/oauth-app@8.0.3':
+    dependencies:
+      '@octokit/auth-oauth-app': 9.0.3
+      '@octokit/auth-oauth-user': 6.0.2
+      '@octokit/auth-unauthenticated': 7.0.3
+      '@octokit/core': 7.0.6
+      '@octokit/oauth-authorization-url': 8.0.0
+      '@octokit/oauth-methods': 6.0.2
+      '@types/aws-lambda': 8.10.157
+      universal-user-agent: 7.0.3
+
+  '@octokit/oauth-authorization-url@8.0.0': {}
+
+  '@octokit/oauth-methods@6.0.2':
+    dependencies:
+      '@octokit/oauth-authorization-url': 8.0.0
+      '@octokit/request': 10.0.6
+      '@octokit/request-error': 7.0.2
+      '@octokit/types': 16.0.0
+
+  '@octokit/openapi-types@27.0.0': {}
+
+  '@octokit/openapi-webhooks-types@12.0.3': {}
+
+  '@octokit/plugin-paginate-graphql@6.0.0(@octokit/core@7.0.6)':
+    dependencies:
+      '@octokit/core': 7.0.6
+
+  '@octokit/plugin-paginate-rest@14.0.0(@octokit/core@7.0.6)':
+    dependencies:
+      '@octokit/core': 7.0.6
+      '@octokit/types': 16.0.0
+
+  '@octokit/plugin-rest-endpoint-methods@17.0.0(@octokit/core@7.0.6)':
+    dependencies:
+      '@octokit/core': 7.0.6
+      '@octokit/types': 16.0.0
+
+  '@octokit/plugin-retry@8.0.3(@octokit/core@7.0.6)':
+    dependencies:
+      '@octokit/core': 7.0.6
+      '@octokit/request-error': 7.0.2
+      '@octokit/types': 16.0.0
+      bottleneck: 2.19.5
+
+  '@octokit/plugin-throttling@11.0.3(@octokit/core@7.0.6)':
+    dependencies:
+      '@octokit/core': 7.0.6
+      '@octokit/types': 16.0.0
+      bottleneck: 2.19.5
+
+  '@octokit/request-error@7.0.2':
+    dependencies:
+      '@octokit/types': 16.0.0
+
+  '@octokit/request@10.0.6':
+    dependencies:
+      '@octokit/endpoint': 11.0.2
+      '@octokit/request-error': 7.0.2
+      '@octokit/types': 16.0.0
+      fast-content-type-parse: 3.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/types@16.0.0':
+    dependencies:
+      '@octokit/openapi-types': 27.0.0
+
+  '@octokit/webhooks-methods@6.0.0': {}
+
+  '@octokit/webhooks@14.1.3':
+    dependencies:
+      '@octokit/openapi-webhooks-types': 12.0.3
+      '@octokit/request-error': 7.0.2
+      '@octokit/webhooks-methods': 6.0.0
+
   '@open-draft/deferred-promise@2.2.0': {}
 
   '@open-draft/logger@0.3.0':
@@ -10238,6 +10524,8 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/aws-lambda@8.10.157': {}
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -10773,6 +11061,8 @@ snapshots:
     dependencies:
       tweetnacl: 0.14.5
 
+  before-after-hook@4.0.0: {}
+
   better-auth@1.3.34(next@16.0.1(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
     dependencies:
       '@better-auth/core': 1.3.34(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.18)(better-call@1.0.19)(jose@6.1.0)(kysely@0.28.8)(nanostores@1.0.1)
@@ -10836,6 +11126,8 @@ snapshots:
       - supports-color
 
   boolbase@1.0.0: {}
+
+  bottleneck@2.19.5: {}
 
   brace-expansion@1.1.12:
     dependencies:
@@ -11754,6 +12046,8 @@ snapshots:
   fast-check@3.23.2:
     dependencies:
       pure-rand: 6.1.0
+
+  fast-content-type-parse@3.0.0: {}
 
   fast-copy@3.0.2: {}
 
@@ -13408,6 +13702,20 @@ snapshots:
       gopd: 1.2.0
       safe-array-concat: 1.1.3
 
+  octokit@5.0.5:
+    dependencies:
+      '@octokit/app': 16.1.2
+      '@octokit/core': 7.0.6
+      '@octokit/oauth-app': 8.0.3
+      '@octokit/plugin-paginate-graphql': 6.0.0(@octokit/core@7.0.6)
+      '@octokit/plugin-paginate-rest': 14.0.0(@octokit/core@7.0.6)
+      '@octokit/plugin-rest-endpoint-methods': 17.0.0(@octokit/core@7.0.6)
+      '@octokit/plugin-retry': 8.0.3(@octokit/core@7.0.6)
+      '@octokit/plugin-throttling': 11.0.3(@octokit/core@7.0.6)
+      '@octokit/request-error': 7.0.2
+      '@octokit/types': 16.0.0
+      '@octokit/webhooks': 14.1.3
+
   ohash@2.0.11: {}
 
   on-exit-leak-free@2.1.2: {}
@@ -14932,6 +15240,8 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  toad-cache@3.7.0: {}
+
   toidentifier@1.0.1: {}
 
   tough-cookie@6.0.0:
@@ -15168,6 +15478,10 @@ snapshots:
       '@types/unist': 3.0.3
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
+
+  universal-github-app-jwt@2.2.2: {}
+
+  universal-user-agent@7.0.3: {}
 
   universalify@0.1.2: {}
 


### PR DESCRIPTION
Using [`octokit-js`](https://github.com/octokit/octokit.js) simplifies any GitHub related stuff. It is well maintained, so not really a risk.

This also adds bruno request for testing GHSA GraphQL endpoint (useful for local dev).