### PR TITLE
Improve Azure DevOps file change handling for Dependabot updates

### DIFF
--- a/.changeset/tidy-azure-diffs.md
+++ b/.changeset/tidy-azure-diffs.md
@@ -1,0 +1,8 @@
+---
+"@paklo/core": patch
+---
+
+Improve Azure DevOps file change handling for Dependabot updates
+- Skip no-op changes and avoid sending bodies for delete operations when pushing PR commits
+- Treat missing content and encoding as optional through the request models and builders
+- Tighten Dependabot dependency file schema with explicit operation and encoding enums

--- a/packages/core/src/azure/models.ts
+++ b/packages/core/src/azure/models.ts
@@ -12,8 +12,8 @@ export const DEVOPS_PR_PROPERTY_DEPENDABOT_DEPENDENCIES = 'Dependabot.Dependenci
 export interface IFileChange {
   changeType: VersionControlChangeType;
   path: string;
-  content: string;
-  encoding: string;
+  content?: string;
+  encoding?: string;
 }
 
 /** Pull request properties */

--- a/packages/core/src/azure/utils.ts
+++ b/packages/core/src/azure/utils.ts
@@ -109,7 +109,7 @@ export function getPullRequestChangedFilesForOutputData(
     .filter((file) => file.type === 'file')
     .map((file) => {
       let changeType = VersionControlChangeType.None;
-      if (file.deleted === true) {
+      if (file.deleted === true || file.operation === 'delete') {
         changeType = VersionControlChangeType.Delete;
       } else if (file.operation === 'update') {
         changeType = VersionControlChangeType.Edit;
@@ -119,8 +119,8 @@ export function getPullRequestChangedFilesForOutputData(
       return {
         changeType: changeType,
         path: path.join(file.directory, file.name),
-        content: file.content ?? '',
-        encoding: file.content_encoding ?? 'utf8',
+        content: file.content ?? undefined,
+        encoding: file.content_encoding ?? undefined,
       } satisfies IFileChange;
     });
 }

--- a/packages/core/src/dependabot/update.ts
+++ b/packages/core/src/dependabot/update.ts
@@ -4,16 +4,34 @@ import { DependabotDependencySchema } from './job';
 // we use nullish() because it does optional() and allows the value to be set to null
 
 export const DependabotDependencyFileSchema = z.object({
+  // https://github.com/dependabot/dependabot-core/blob/5e2711f9913cc387acb7cb0d29d51fb52d235ef2/common/lib/dependabot/dependency_file.rb#L14-L15
   content: z.string().nullish(),
-  content_encoding: z.string().nullish(),
+  content_encoding: z.enum(['utf-8', 'base64']).nullish(),
   deleted: z.boolean().nullish(),
   directory: z.string(),
   name: z.string(),
-  operation: z.string(), // TODO: convert to enum?
+  operation: z.enum(['update', 'create', 'delete']),
   support_file: z.boolean().nullish(),
+  vendored_file: z.boolean().nullish(),
   symlink_target: z.string().nullish(),
-  type: z.string().nullish(), // TODO: convert to enum?
-  mode: z.string().nullish(),
+  type: z.string().nullish(),
+  // mode: z.enum([
+  //   '100755', // executable
+  //   '100644', // file
+  //   '040000', // directory
+  //   '160000', // submodule
+  //   "120000", // symlink
+  // ]).nullish(),
+  mode: z
+    .enum({
+      executable: '100755',
+      file: '100644',
+      directory: '040000',
+      submodule: '160000',
+      symlink: '120000',
+    })
+    .or(z.string())
+    .nullish(),
 });
 export type DependabotDependencyFile = z.infer<typeof DependabotDependencyFileSchema>;
 


### PR DESCRIPTION
- Skip no-op changes and avoid sending bodies for delete operations when pushing PR commits
- Treat missing content and encoding as optional through the request models and builders
- Tighten Dependabot dependency file schema with explicit operation and encoding enums