### PR TITLE
Support for `record_update_job_warning` by creating comments on modified pull requests.

### DIFF
--- a/.changeset/wise-moments-deny.md
+++ b/.changeset/wise-moments-deny.md
@@ -1,0 +1,8 @@
+---
+"@paklo/runner": minor
+"@paklo/core": minor
+---
+
+Support for `record_update_job_warning` by creating comments on modified pull requests.
+The `record_update_job_warning` is based on dependabot notices and is for scenarios such as when the package manager is outdated and Dependabot would stop supporting it.
+There are other scenarios when notices are generated.

--- a/apps/web/src/app/api/update_jobs/[...all]/route.ts
+++ b/apps/web/src/app/api/update_jobs/[...all]/route.ts
@@ -86,7 +86,8 @@ async function handleRequest(id: string, request: DependabotRequest): Promise<bo
     // TODO: implement actual logic
     case 'create_pull_request':
     case 'update_pull_request':
-    case 'close_pull_request': {
+    case 'close_pull_request':
+    case 'record_update_job_warning': {
       return true;
     }
 

--- a/packages/core/src/azure/models.ts
+++ b/packages/core/src/azure/models.ts
@@ -88,3 +88,12 @@ export interface IAbandonPullRequest {
   comment?: string;
   deleteSourceBranch?: boolean;
 }
+
+/** Pull request comment */
+export interface IPullRequestComment {
+  project: string;
+  repository: string;
+  pullRequestId: number;
+  content: string;
+  userId?: string;
+}

--- a/packages/core/src/dependabot/server.ts
+++ b/packages/core/src/dependabot/server.ts
@@ -13,6 +13,7 @@ import {
   DependabotRecordEcosystemVersionsSchema,
   DependabotRecordUpdateJobErrorSchema,
   DependabotRecordUpdateJobUnknownErrorSchema,
+  DependabotRecordUpdateJobWarningSchema,
   DependabotUpdateDependencyListSchema,
   DependabotUpdatePullRequestSchema,
 } from './update';
@@ -22,6 +23,7 @@ export const DependabotRequestTypeSchema = z.enum([
   'update_pull_request',
   'close_pull_request',
   'record_update_job_error',
+  'record_update_job_warning',
   'record_update_job_unknown_error',
   'mark_as_processed',
   'update_dependency_list',
@@ -37,6 +39,7 @@ export const DependabotRequestSchema = z.discriminatedUnion('type', [
   z.object({ type: z.literal('update_pull_request'), data: DependabotUpdatePullRequestSchema }),
   z.object({ type: z.literal('close_pull_request'), data: DependabotClosePullRequestSchema }),
   z.object({ type: z.literal('record_update_job_error'), data: DependabotRecordUpdateJobErrorSchema }),
+  z.object({ type: z.literal('record_update_job_warning'), data: DependabotRecordUpdateJobWarningSchema }),
   z.object({ type: z.literal('record_update_job_unknown_error'), data: DependabotRecordUpdateJobUnknownErrorSchema }),
   z.object({ type: z.literal('mark_as_processed'), data: DependabotMarkAsProcessedSchema }),
   z.object({ type: z.literal('update_dependency_list'), data: DependabotUpdateDependencyListSchema }),
@@ -127,6 +130,7 @@ export function createApiServerApp({
   // - POST  request to /update_pull_request
   // - POST  request to /close_pull_request
   // - POST  request to /record_update_job_error
+  // - POST  request to /record_update_job_warning
   // - POST  request to /record_update_job_unknown_error
   // - PATCH request to /mark_as_processed
   // - POST  request to /update_dependency_list
@@ -173,6 +177,7 @@ export function createApiServerApp({
   operation('update_pull_request', DependabotUpdatePullRequestSchema);
   operation('close_pull_request', DependabotClosePullRequestSchema);
   operation('record_update_job_error', DependabotRecordUpdateJobErrorSchema);
+  operation('record_update_job_warning', DependabotRecordUpdateJobWarningSchema);
   operation('record_update_job_unknown_error', DependabotRecordUpdateJobUnknownErrorSchema);
   operation('mark_as_processed', DependabotMarkAsProcessedSchema, 'patch');
   operation('update_dependency_list', DependabotUpdateDependencyListSchema);

--- a/packages/core/src/dependabot/update.ts
+++ b/packages/core/src/dependabot/update.ts
@@ -88,6 +88,13 @@ export const DependabotRecordUpdateJobErrorSchema = z.object({
 });
 export type DependabotRecordUpdateJobError = z.infer<typeof DependabotRecordUpdateJobErrorSchema>;
 
+export const DependabotRecordUpdateJobWarningSchema = z.object({
+  'warn-type': z.string(),
+  'warn-title': z.string(),
+  'warn-description': z.string(),
+});
+export type DependabotRecordUpdateJobWarning = z.infer<typeof DependabotRecordUpdateJobWarningSchema>;
+
 export const DependabotRecordUpdateJobUnknownErrorSchema = z.object({
   'error-type': z.string(),
   'error-details': z.record(z.string(), z.any()).nullish(),

--- a/packages/runner/src/local/azure/server.test.ts
+++ b/packages/runner/src/local/azure/server.test.ts
@@ -27,6 +27,7 @@ describe('AzureLocalDependabotServer', () => {
       createPullRequest: vi.fn(),
       updatePullRequest: vi.fn(),
       abandonPullRequest: vi.fn(),
+      addCommentThread: vi.fn(),
       approvePullRequest: vi.fn(),
       getDefaultBranch: vi.fn(),
     } as unknown as AzureDevOpsWebApiClient;
@@ -377,6 +378,38 @@ describe('AzureLocalDependabotServer', () => {
 
       expect(result).toEqual(true);
       expect(authorClient.abandonPullRequest).toHaveBeenCalled();
+    });
+
+    it('should process "record_update_job_warning" if "dryRun" is true', async () => {
+      options.dryRun = true;
+
+      vi.mocked(authorClient.addCommentThread).mockResolvedValue(1);
+
+      const result = await (server as any).handle('1', {
+        type: 'record_update_job_warning',
+        data: {
+          'warn-type': 'deprecated_dependency',
+          'warn-title': 'Deprecated Dependency Used',
+          'warn-description': 'The dependency xyz is deprecated and should be updated or removed.',
+        },
+      });
+      expect(result).toEqual(true);
+      expect(authorClient.addCommentThread).not.toHaveBeenCalled();
+    });
+
+    it('should process "record_update_job_warning"', async () => {
+      vi.mocked(authorClient.addCommentThread).mockResolvedValue(1);
+
+      const result = await (server as any).handle('1', {
+        type: 'record_update_job_warning',
+        data: {
+          'warn-type': 'deprecated_dependency',
+          'warn-title': 'Deprecated Dependency Used',
+          'warn-description': 'The dependency xyz is deprecated and should be updated or removed.',
+        },
+      });
+      expect(result).toEqual(true);
+      expect(authorClient.addCommentThread).toHaveBeenCalled();
     });
 
     it('should process "mark_as_processed"', async () => {

--- a/packages/runner/src/local/azure/server.ts
+++ b/packages/runner/src/local/azure/server.ts
@@ -269,6 +269,26 @@ export class AzureLocalDependabotServer extends LocalDependabotServer {
         return false;
       }
 
+      case 'record_update_job_warning': {
+        if (dryRun) {
+          logger.warn(`Skipping warning as 'dryRun' is set to 'true'`);
+          return true;
+        }
+
+        // add comment to each create/updated pull request
+        const ids = affectedPullRequestIds.get(id)!.created.concat(affectedPullRequestIds.get(id)!.updated);
+        for (const pullRequestId of ids) {
+          await authorClient.addCommentThread({
+            project: project,
+            repository: repository,
+            content: `### Dependabot Warning: ${data['warn-title']}\n\n${data['warn-description']}`,
+            pullRequestId,
+          });
+        }
+
+        return true;
+      }
+
       // No action required
       case 'update_dependency_list':
       case 'mark_as_processed':


### PR DESCRIPTION
The `record_update_job_warning` is based on dependabot notices and is for scenarios such as when the package manager is outdated and Dependabot would stop supporting it. There are other scenarios when notices.