### PR TITLE
Support for `create_dependency_submission` requests.

### DIFF
--- a/.changeset/fuzzy-parks-drop.md
+++ b/.changeset/fuzzy-parks-drop.md
@@ -1,0 +1,8 @@
+---
+"@paklo/runner": minor
+"@paklo/core": minor
+---
+
+Support for `create_dependency_submission` requests.
+While these requests are doing nothing at this time, it helps keep similar request possibilities to avoid jobs failing because of 404 responses.
+This could also be used in the managed version to support SBOM or checking vulnerabilities.

--- a/apps/web/src/app/api/update_jobs/[...all]/route.ts
+++ b/apps/web/src/app/api/update_jobs/[...all]/route.ts
@@ -87,6 +87,7 @@ async function handleRequest(id: string, request: DependabotRequest): Promise<bo
     case 'create_pull_request':
     case 'update_pull_request':
     case 'close_pull_request':
+    case 'create_dependency_submission': // can be used for SBOM or checking vulnerabilities
     case 'record_update_job_warning': {
       return true;
     }

--- a/packages/core/fixtures/create_dependency_submission/terraform.json
+++ b/packages/core/fixtures/create_dependency_submission/terraform.json
@@ -1,0 +1,18 @@
+{
+  "type": "create_dependency_submission",
+  "data": {
+    "version": 1,
+    "sha": "41fa8b4fe8d90fe7db38d4b730768e7dc52bc983",
+    "ref": "refs/heads/main",
+    "job": {
+      "correlator": "dependabot-terraform-**-terraform",
+      "id": "3302222848"
+    },
+    "detector": {
+      "name": "dependabot",
+      "version": "0.349.0-25e6e4a90121d8f8dae0c687f99ccd0aa15a7db6dd1ba623bbee7d766936e0aa",
+      "url": "https://github.com/dependabot/dependabot-core"
+    },
+    "manifests": {}
+  }
+}

--- a/packages/core/src/dependabot/server.ts
+++ b/packages/core/src/dependabot/server.ts
@@ -6,6 +6,7 @@ import type { DependabotCredential, DependabotJobConfig } from './job';
 import {
   DependabotClosePullRequestSchema,
   DependabotCreatePullRequestSchema,
+  DependabotDependencySubmissionSchema,
   DependabotIncrementMetricSchema,
   DependabotMarkAsProcessedSchema,
   DependabotMetricSchema,
@@ -27,6 +28,7 @@ export const DependabotRequestTypeSchema = z.enum([
   'record_update_job_unknown_error',
   'mark_as_processed',
   'update_dependency_list',
+  'create_dependency_submission',
   'record_ecosystem_versions',
   'record_ecosystem_meta',
   'increment_metric',
@@ -43,6 +45,7 @@ export const DependabotRequestSchema = z.discriminatedUnion('type', [
   z.object({ type: z.literal('record_update_job_unknown_error'), data: DependabotRecordUpdateJobUnknownErrorSchema }),
   z.object({ type: z.literal('mark_as_processed'), data: DependabotMarkAsProcessedSchema }),
   z.object({ type: z.literal('update_dependency_list'), data: DependabotUpdateDependencyListSchema }),
+  z.object({ type: z.literal('create_dependency_submission'), data: DependabotDependencySubmissionSchema }),
   z.object({ type: z.literal('record_ecosystem_versions'), data: DependabotRecordEcosystemVersionsSchema }),
   z.object({ type: z.literal('record_ecosystem_meta'), data: DependabotRecordEcosystemMetaSchema.array() }),
   z.object({ type: z.literal('increment_metric'), data: DependabotIncrementMetricSchema }),
@@ -134,6 +137,7 @@ export function createApiServerApp({
   // - POST  request to /record_update_job_unknown_error
   // - PATCH request to /mark_as_processed
   // - POST  request to /update_dependency_list
+  // - POST  request to /create_dependency_submission
   // - POST  request to /record_ecosystem_versions
   // - POST  request to /record_ecosystem_meta
   // - POST  request to /increment_metric
@@ -181,6 +185,7 @@ export function createApiServerApp({
   operation('record_update_job_unknown_error', DependabotRecordUpdateJobUnknownErrorSchema);
   operation('mark_as_processed', DependabotMarkAsProcessedSchema, 'patch');
   operation('update_dependency_list', DependabotUpdateDependencyListSchema);
+  operation('create_dependency_submission', DependabotDependencySubmissionSchema);
   operation('record_ecosystem_versions', DependabotRecordEcosystemVersionsSchema);
   operation('record_ecosystem_meta', DependabotRecordEcosystemMetaSchema.array());
   operation('increment_metric', DependabotIncrementMetricSchema);

--- a/packages/core/src/dependabot/update.test.ts
+++ b/packages/core/src/dependabot/update.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   DependabotCreatePullRequestSchema,
+  DependabotDependencySubmissionSchema,
   DependabotIncrementMetricSchema,
   DependabotMarkAsProcessedSchema,
   DependabotMetricSchema,
@@ -10,6 +11,26 @@ import {
   DependabotRecordEcosystemVersionsSchema,
   DependabotUpdateDependencyListSchema,
 } from './update';
+
+describe('create_dependency_submission', () => {
+  it('terraform', async () => {
+    const raw = JSON.parse(await readFile('fixtures/create_dependency_submission/terraform.json', 'utf-8'));
+    const data = DependabotDependencySubmissionSchema.parse(raw.data);
+
+    expect(data.version).toEqual(1);
+    expect(data.sha).toEqual('41fa8b4fe8d90fe7db38d4b730768e7dc52bc983');
+    expect(data.ref).toEqual('refs/heads/main');
+    expect(data.job.id).toEqual('3302222848');
+    expect(data.job.correlator).toEqual('dependabot-terraform-**-terraform');
+    expect(data.detector.name).toEqual('dependabot');
+    expect(data.detector.version).toEqual('0.349.0-25e6e4a90121d8f8dae0c687f99ccd0aa15a7db6dd1ba623bbee7d766936e0aa');
+    expect(data.detector.url).toEqual('https://github.com/dependabot/dependabot-core');
+    expect(data.manifests.name).toBeUndefined();
+    expect(data.manifests.file).toBeUndefined();
+    expect(data.manifests.metadata).toBeUndefined();
+    expect(data.manifests.resolved).toBeUndefined();
+  });
+});
 
 describe('create_pull_request', () => {
   it('python-pip', async () => {

--- a/packages/core/src/dependabot/update.ts
+++ b/packages/core/src/dependabot/update.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { DependabotDependencySchema } from './job';
+import { DependabotDependencySchema, DependabotPackageManagerSchema } from './job';
 
 // we use nullish() because it does optional() and allows the value to be set to null
 
@@ -40,6 +40,35 @@ export const DependabotUpdateDependencyListSchema = z.object({
   dependency_files: z.string().array().nullish(),
 });
 export type DependabotUpdateDependencyList = z.infer<typeof DependabotUpdateDependencyListSchema>;
+
+export const DependabotDependencySubmissionSchema = z.object({
+  version: z.number(),
+  sha: z.string(),
+  ref: z.string(),
+  job: z.object({
+    correlator: z.string(),
+    id: z.string(),
+  }),
+  detector: z.object({
+    name: z.string(),
+    version: z.string(),
+    url: z.string(),
+  }),
+  manifests: z.object({
+    name: z.string().nullish(),
+    file: z.object({ source_location: z.string() }).nullish(),
+    metadata: z.object({ ecosystem: DependabotPackageManagerSchema }).nullish(),
+    resolved: z
+      .object({
+        package_url: z.string(),
+        relationship: z.enum(['direct', 'indirect']),
+        scope: z.enum(['runtime', 'development']),
+        dependencies: DependabotDependencySchema.array(),
+      })
+      .nullish(),
+  }),
+});
+export type DependabotDependencySubmission = z.infer<typeof DependabotDependencySubmissionSchema>;
 
 export const DependabotCreatePullRequestSchema = z.object({
   'base-commit-sha': z.string(),

--- a/packages/runner/src/local/azure/server.test.ts
+++ b/packages/runner/src/local/azure/server.test.ts
@@ -126,6 +126,29 @@ describe('AzureLocalDependabotServer', () => {
       expect(result).toEqual(true);
     });
 
+    it('should process "create_dependency_submission"', async () => {
+      const result = await (server as any).handle('1', {
+        type: 'create_dependency_submission',
+        data: {
+          version: 1,
+          sha: '41fa8b4fe8d90fe7db38d4b730768e7dc52bc983',
+          ref: 'refs/heads/main',
+          job: {
+            correlator: 'dependabot-terraform-**-terraform',
+            id: '3302222848',
+          },
+          detector: {
+            name: 'dependabot',
+            version: '0.349.0-25e6e4a90121d8f8dae0c687f99ccd0aa15a7db6dd1ba623bbee7d766936e0aa',
+            url: 'https://github.com/dependabot/dependabot-core',
+          },
+          manifests: {},
+        },
+      });
+
+      expect(result).toEqual(true);
+    });
+
     it('should skip processing "create_pull_request" if "dryRun" is true', async () => {
       options.dryRun = true;
       server = new AzureLocalDependabotServer(options);

--- a/packages/runner/src/local/azure/server.ts
+++ b/packages/runner/src/local/azure/server.ts
@@ -291,6 +291,7 @@ export class AzureLocalDependabotServer extends LocalDependabotServer {
 
       // No action required
       case 'update_dependency_list':
+      case 'create_dependency_submission':
       case 'mark_as_processed':
       case 'record_ecosystem_versions':
       case 'record_ecosystem_meta':


### PR DESCRIPTION
While these requests are doing nothing at this time, it helps keep similar request possibilities to avoid jobs failing because of 404 responses. This could also be used in the managed version to support SBOM or checking vulnerabilities.