### PR TITLE
Add request inspection support for troubleshooting.

### DIFF
--- a/.changeset/sharp-inspections-capture.md
+++ b/.changeset/sharp-inspections-capture.md
@@ -1,0 +1,8 @@
+---
+"@paklo/cli": minor
+"@paklo/core": minor
+---
+
+Add request inspection support for troubleshooting.
+- CLI `run` command can write raw Dependabot requests with `--inspect`, writing JSON snapshots under `./inspections`.
+- Core server accepts an optional inspect hook that records the raw request payload before processing.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -79,6 +79,7 @@ paklo run --organisation-url <ORGANISATION-URL> --project <PROJECT> --repository
 - `--updater-image <IMAGE>` - Custom updater Docker image
 - `--dry-run` - Run without making changes
 - `--debug` - Enable debug logging
+- `--inspect` - Write raw Dependabot API requests to `./inspections` for troubleshooting
 
 **Example:**
 


### PR DESCRIPTION
- CLI `run` command can write raw Dependabot requests with `--inspect`, writing JSON snapshots under `./inspections`.
- Core server accepts an optional inspect hook that records the raw request payload before processing.