### PR TITLE
More secure session checks in proxy

### DIFF
--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -1,14 +1,9 @@
-import { getSessionCookie } from 'better-auth/cookies';
 import { type NextRequest, NextResponse, type ProxyConfig } from 'next/server';
+import { auth } from '@/lib/auth';
 
 export async function proxy(request: NextRequest) {
   const headers = new Headers(request.headers);
-  // TODO: investigate this further:
-  // getSessionCookie is sync and faster than calling auth.api.getSession
-  // As of 2025-Nov-10 using Next 16.0.1 (renamed middleware to proxy), auth.api.getSession
-  // makes the request timeout.
-  // const session = await auth.api.getSession({ headers });
-  const session = getSessionCookie(request);
+  const session = await auth.api.getSession({ headers });
   const { nextUrl: url } = request;
   const { pathname } = url;
 


### PR DESCRIPTION
This not only checks the session cookie exists but validates it is known and not expired.

Initially disabled when using next 16.0.1