### PR TITLE
Require schedule to be present in the updates configuration.

### DIFF
--- a/.changeset/light-needles-clap.md
+++ b/.changeset/light-needles-clap.md
@@ -1,0 +1,10 @@
+---
+"@paklo/runner": minor
+"@paklo/core": minor
+"extension-azure-devops": minor
+"@paklo/cli": minor
+---
+
+Require schedule to be present in the updates configuration.
+Anyone using `.github/dependabot.{yaml,yml}` already has schema warnings in the IDE.
+This change is another step to bringing parity to the GitHub-hosted version and is necessary for our hosted version.

--- a/apps/web/src/workflows/sync/synchronizer.ts
+++ b/apps/web/src/workflows/sync/synchronizer.ts
@@ -307,8 +307,8 @@ export class Synchronizer {
     const updatesToUpsert = updates;
     for (const update of updatesToUpsert) {
       const directoryKey = makeDirectoryKey(update);
-      const timezone = update.schedule?.timezone || 'UTC'; // TODO: remove nullable and default once schedule is enforced
-      const { cron, next: nextUpdateJobAt } = generateCron(update.schedule!, timezone); // TODO: remove assertion once schedule is enforced
+      const timezone = update.schedule.timezone;
+      const { cron, next: nextUpdateJobAt } = generateCron(update.schedule, timezone);
       await prisma.repositoryUpdate.upsert({
         where: {
           repositoryId_ecosystem_directoryKey: {

--- a/packages/core/fixtures/config/dependabot.yml
+++ b/packages/core/fixtures/config/dependabot.yml
@@ -5,47 +5,63 @@
 
 version: 2
 updates:
-  - package-ecosystem: 'docker' # See documentation for possible values
-    directory: '/' # Location of package manifests
+  - package-ecosystem: "docker" # See documentation for possible values
+    schedule:
+      interval: "cron"
+      cronjob: "0 0 * * *"
+    directory: "/" # Location of package manifests
     open-pull-requests-limit: 10
-  - package-ecosystem: 'npm' # See documentation for possible values
-    directory: '/client' # Location of package manifests
+  - package-ecosystem: "npm" # See documentation for possible values
+    schedule:
+      interval: "cron"
+      cronjob: "0 0 * * *"
+    directory: "/client" # Location of package manifests
     open-pull-requests-limit: 10
     registries:
       - reg1
       - reg2
-    insecure-external-code-execution: 'deny'
+    insecure-external-code-execution: "deny"
     ignore:
-      - dependency-name: 'react'
-        update-types: ['version-update:semver-major']
-      - dependency-name: 'react-dom'
-        update-types: ['version-update:semver-major']
-      - dependency-name: '@types/react'
-        update-types: ['version-update:semver-major']
-      - dependency-name: '@types/react-dom'
-        update-types: ['version-update:semver-major']
-  - package-ecosystem: 'nuget'
+      - dependency-name: "react"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "react-dom"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@types/react"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@types/react-dom"
+        update-types: ["version-update:semver-major"]
+  - package-ecosystem: "nuget"
+    schedule:
+      interval: "cron"
+      cronjob: "0 0 * * *"
     directories:
-      - '/src/client'
-      - '/src/server'
+      - "/src/client"
+      - "/src/server"
     groups:
       microsoft:
         patterns:
-          - 'microsoft*'
+          - "microsoft*"
         update-types:
-          - 'minor'
-          - 'patch'
-  - package-ecosystem: 'devcontainers' # See documentation for possible values
-    directory: '/' # Location of package manifests
+          - "minor"
+          - "patch"
+  - package-ecosystem: "devcontainers" # See documentation for possible values
+    schedule:
+      interval: "weekly"
+      day: "thursday"
+      time: "12:00"
+      timezone: "UTC"
+    directory: "/" # Location of package manifests
     open-pull-requests-limit: 0
-  - package-ecosystem: 'dotnet-sdk' # See documentation for possible values
-    directory: '/' # Location of package manifests
+  - package-ecosystem: "dotnet-sdk" # See documentation for possible values
+    schedule:
+      interval: "daily"
+    directory: "/" # Location of package manifests
 registries:
   reg1:
     type: nuget-feed
-    url: 'https://pkgs.dev.azure.com/dependabot/_packaging/dependabot/nuget/v3/index.json'
-    token: ':${{DEFAULT_TOKEN}}'
+    url: "https://pkgs.dev.azure.com/dependabot/_packaging/dependabot/nuget/v3/index.json"
+    token: ":${{DEFAULT_TOKEN}}"
   reg2:
     type: npm-registry
-    url: 'https://pkgs.dev.azure.com/dependabot/_packaging/dependabot-npm/npm/registry/'
-    token: 'tingle-npm:${{ DEFAULT_TOKEN }}'
+    url: "https://pkgs.dev.azure.com/dependabot/_packaging/dependabot-npm/npm/registry/"
+    token: "tingle-npm:${{ DEFAULT_TOKEN }}"

--- a/packages/core/fixtures/config/sample-registries.yml
+++ b/packages/core/fixtures/config/sample-registries.yml
@@ -1,7 +1,10 @@
 version: 2
 updates:
-  - package-ecosystem: 'docker' # See documentation for possible values
-    directory: '/' # Location of package manifests
+  - package-ecosystem: "docker" # See documentation for possible values
+    schedule:
+      interval: "cron"
+      cronjob: "0 0 * * *"
+    directory: "/" # Location of package manifests
     open-pull-requests-limit: 10
 registries:
   cargo:
@@ -13,70 +16,70 @@ registries:
     type: composer-repository
     url: https://repo.packagist.com/example-company/
     username: octocat
-    password: 'pwd_1234567890'
+    password: "pwd_1234567890"
   dockerhub:
     type: docker-registry
     url: https://registry.hub.docker.com
     username: octocat
-    password: 'pwd_1234567890'
+    password: "pwd_1234567890"
     replaces-base: true
   github-octocat:
     type: git
     url: https://github.com
     username: x-access-token
-    password: 'pwd_1234567890'
+    password: "pwd_1234567890"
   goproxy:
     type: goproxy-server
     url: https://acme.jfrog.io/artifactory/api/go/my-repo
     username: octocat
-    password: 'pwd_1234567890'
+    password: "pwd_1234567890"
   helm:
     type: helm-registry
     url: https://registry.example.com
     username: octocat
-    password: 'pwd_1234567890'
+    password: "pwd_1234567890"
   github-hex-org:
     type: hex-organization
     organization: github
-    key: 'key_1234567890'
+    key: "key_1234567890"
   github-hex-repository:
     type: hex-repository
     repo: private-repo
     url: https://private-repo.example.com
-    auth-key: 'ak_1234567890'
-    public-key-fingerprint: 'pkf_1234567890'
+    auth-key: "ak_1234567890"
+    public-key-fingerprint: "pkf_1234567890"
   maven-artifactory:
     type: maven-repository
     url: https://artifactory.example.com
     username: octocat
-    password: 'pwd_1234567890'
+    password: "pwd_1234567890"
     replaces-base: true
   npm-github:
     type: npm-registry
     url: https://npm.pkg.github.com
-    token: 'tkn_1234567890'
+    token: "tkn_1234567890"
     replaces-base: true
   nuget-azure-devops:
     type: nuget-feed
     url: https://pkgs.dev.azure.com/contoso/_packaging/My_Feed/nuget/v3/index.json
     username: octocat@example.com
-    password: 'pwd_1234567890'
+    password: "pwd_1234567890"
   my-pub-registry:
     type: pub-repository
     url: https://example-private-pub-repo.dev/optional-path
-    token: 'tkn_1234567890'
+    token: "tkn_1234567890"
   python-azure:
     type: python-index
     url: https://pkgs.dev.azure.com/octocat/_packaging/my-feed/pypi/example
     username: octocat@example.com
-    password: 'pwd_1234567890'
+    password: "pwd_1234567890"
     replaces-base: true
   ruby-github:
     type: rubygems-server
     url: https://rubygems.pkg.github.com/octocat/github_api
-    token: 'tkn_1234567890'
+    token: "tkn_1234567890"
     replaces-base: false
   terraform-example:
     type: terraform-registry
     url: https://terraform.example.com
-    token: 'tkn_1234567890'
+    token: "tkn_1234567890"

--- a/packages/core/src/dependabot/config.ts
+++ b/packages/core/src/dependabot/config.ts
@@ -216,7 +216,7 @@ export const DependabotUpdateSchema = z
     'pull-request-branch-name': DependabotPullRequestBranchNameSchema.optional(),
     'rebase-strategy': z.string().optional(),
     registries: z.string().array().optional(),
-    schedule: DependabotScheduleSchema.optional(), // TODO: make required after 2025-Nov-30
+    schedule: DependabotScheduleSchema,
     'target-branch': z.string().optional(),
     vendor: z.boolean().optional(),
     'versioning-strategy': VersioningStrategySchema.optional(),

--- a/packages/core/src/dependabot/job-builder.test.ts
+++ b/packages/core/src/dependabot/job-builder.test.ts
@@ -74,6 +74,7 @@ describe('mapSourceFromDependabotConfigToJobConfig', () => {
     };
     const update = {
       'package-ecosystem': 'nuget',
+      schedule: { interval: 'daily', time: '02:00', timezone: 'UTC', day: 'sunday' },
       directory: '/',
       directories: [],
     } as DependabotUpdate;
@@ -96,6 +97,7 @@ describe('mapSourceFromDependabotConfigToJobConfig', () => {
     };
     const update = {
       'package-ecosystem': 'nuget',
+      schedule: { interval: 'daily', time: '02:00', timezone: 'UTC', day: 'sunday' },
       directory: '/',
       directories: [],
     } as DependabotUpdate;

--- a/packages/runner/src/local/azure/runner.ts
+++ b/packages/runner/src/local/azure/runner.ts
@@ -75,17 +75,6 @@ export class AzureLocalJobsRunner extends LocalJobsRunner {
       );
     }
 
-    // Print a warning about missing schedules
-    // TODO: remove this and enforce schedules on or after 2025-Nov-30
-    if (config.updates?.some((u) => !u.schedule)) {
-      logger.warn(
-        `
-        Some updates are missing a schedule configuration.
-        This tool will require all updates to have a schedule on or after 2025-Nov-30.
-        `,
-      );
-    }
-
     // Print a warning about the required workarounds for security-only updates, if any update is configured as such
     // TODO: If and when Dependabot supports a better way to do security-only updates, remove this.
     if (config.updates?.some((u) => u['open-pull-requests-limit'] === 0)) {

--- a/packages/runner/src/local/azure/server.test.ts
+++ b/packages/runner/src/local/azure/server.test.ts
@@ -102,6 +102,7 @@ describe('AzureLocalDependabotServer', () => {
       };
       update = {
         'package-ecosystem': 'npm',
+        schedule: { interval: 'daily', time: '02:00', timezone: 'UTC', day: 'sunday' },
       };
 
       // Mock the job and update methods


### PR DESCRIPTION
Anyone using `.github/dependabot.{yaml,yml}` already has schema warnings in the IDE. This change is another step to bringing parity to the GitHub-hosted version and is necessary for our hosted version.