### PR TITLE
Do not log proxy output unless debug is enabled.

### DIFF
--- a/.changeset/wild-frogs-think.md
+++ b/.changeset/wild-frogs-think.md
@@ -1,0 +1,6 @@
+---
+"@paklo/runner": minor
+---
+
+Do not log proxy output unless debug is enabled.
+This should reduce the number of logs and avoid hitting the pipelines log file limit.

--- a/packages/runner/src/local/azure/runner.ts
+++ b/packages/runner/src/local/azure/runner.ts
@@ -260,6 +260,8 @@ export class AzureLocalJobsRunner extends LocalJobsRunner {
       let jobToken: string;
       let credentialsToken: string;
 
+      const debug = this.options.debug;
+
       // If this is a security-only update (i.e. 'open-pull-requests-limit: 0'), then we first need to discover the dependencies
       // that need updating and check each one for vulnerabilities. This is because Dependabot requires the list of vulnerable dependencies
       // to be supplied in the job definition of security-only update job, it will not automatically discover them like a versioned update does.
@@ -282,6 +284,7 @@ export class AzureLocalJobsRunner extends LocalJobsRunner {
           credentialsToken,
           updaterImage,
           secretMasker,
+          debug,
           usage: makeUsageData(job),
         });
 
@@ -366,6 +369,7 @@ export class AzureLocalJobsRunner extends LocalJobsRunner {
             credentialsToken,
             updaterImage,
             secretMasker,
+            debug,
             usage: makeUsageData(job),
           });
           const affectedPrs = server.allAffectedPrs(id);
@@ -403,6 +407,7 @@ export class AzureLocalJobsRunner extends LocalJobsRunner {
               credentialsToken,
               updaterImage,
               secretMasker,
+              debug,
               usage: makeUsageData(job),
             });
             const affectedPrs = server.allAffectedPrs(id);

--- a/packages/runner/src/proxy.ts
+++ b/packages/runner/src/proxy.ts
@@ -4,7 +4,7 @@ import { logger } from '@paklo/core/logger';
 import type Docker from 'dockerode';
 import type { Container, Network } from 'dockerode';
 import { ContainerService } from './container-service';
-import { errStream, outStream } from './utils';
+import { errStream, nullStream, outStream } from './utils';
 
 // Code below is borrowed and adapted from dependabot-action
 
@@ -37,6 +37,7 @@ export class ProxyBuilder {
     private readonly docker: Docker,
     private readonly proxyImage: string,
     private readonly cachedMode: boolean,
+    private readonly debug: boolean,
   ) {}
 
   async run(
@@ -80,7 +81,7 @@ export class ProxyBuilder {
       stdout: true,
       stderr: true,
     });
-    container.modem.demuxStream(stream, outStream('  proxy'), errStream('  proxy'));
+    container.modem.demuxStream(stream, this.debug ? outStream('  proxy') : nullStream, errStream('  proxy'));
 
     const url = async (): Promise<string> => {
       const containerInfo = await container.inspect();

--- a/packages/runner/src/run.ts
+++ b/packages/runner/src/run.ts
@@ -25,12 +25,14 @@ export type RunJobOptions = {
   credentialsToken: string;
   updaterImage?: string;
   secretMasker: SecretMasker;
+  debug: boolean;
   usage: Pick<UsageTelemetryRequestData, 'trigger' | 'provider' | 'owner' | 'project' | 'package-manager'>;
 };
 export type RunJobResult = { success: true; message?: string } | { success: false; message: string };
 
 export async function runJob(options: RunJobOptions): Promise<RunJobResult> {
-  const { jobId, dependabotApiUrl, dependabotApiDockerUrl, jobToken, credentialsToken, secretMasker, usage } = options;
+  const { jobId, dependabotApiUrl, dependabotApiDockerUrl, jobToken, credentialsToken, secretMasker, debug, usage } =
+    options;
 
   const started = new Date();
   let success = false;
@@ -71,7 +73,7 @@ export async function runJob(options: RunJobOptions): Promise<RunJobResult> {
 
     const credentials = (await apiClient.getCredentials()) || [];
 
-    const updater = new Updater(updaterImage, PROXY_IMAGE_NAME, params, job, credentials);
+    const updater = new Updater(updaterImage, PROXY_IMAGE_NAME, params, job, credentials, debug);
 
     try {
       // Using sendMetricsWithPackageManager wrapper to inject package manager tag to

--- a/packages/runner/src/updater.ts
+++ b/packages/runner/src/updater.ts
@@ -23,6 +23,7 @@ export class Updater {
     private readonly params: JobParameters,
     private readonly job: DependabotJobConfig,
     private readonly credentials: DependabotCredential[],
+    private readonly debug: boolean,
   ) {
     this.docker = new Docker();
     this.job['credentials-metadata'] = this.generateCredentialsMetadata();
@@ -34,7 +35,7 @@ export class Updater {
   async runUpdater(): Promise<boolean> {
     const cachedMode = Object.hasOwn(this.job.experiments, 'proxy-cached') === true;
 
-    const proxyBuilder = new ProxyBuilder(this.docker, this.proxyImage, cachedMode);
+    const proxyBuilder = new ProxyBuilder(this.docker, this.proxyImage, cachedMode, this.debug);
 
     const proxy = await proxyBuilder.run(
       this.params.jobId,

--- a/packages/runner/src/utils.ts
+++ b/packages/runner/src/utils.ts
@@ -2,6 +2,8 @@ import stream, { type Writable } from 'node:stream';
 
 // Code below is borrowed and adapted from dependabot-action
 
+export const nullStream: Writable = new stream.Writable({ write: (__, _, next) => next() });
+
 export const outStream = (prefix: string): Writable => {
   return new stream.Writable({
     write(chunk, _, next) {


### PR DESCRIPTION
This should reduce the number of logs and avoid hitting the pipelines log file limit.