### PR TITLE
Avoid double encoding or project/repository in Azure DevOps URLs

### DIFF
--- a/.changeset/strong-falcons-burn.md
+++ b/.changeset/strong-falcons-burn.md
@@ -1,0 +1,6 @@
+---
+"extension-azure-devops": patch
+"@paklo/core": patch
+---
+
+Refactor URL handling in Azure DevOps client or prevent double encoding of project and repository names

--- a/extensions/azure/src/v2/inputs.ts
+++ b/extensions/azure/src/v2/inputs.ts
@@ -60,10 +60,10 @@ export type TaskInputs = {
 export function getTaskInputs(): TaskInputs {
   let project = tl.getInput('targetProjectName');
   const projectOverridden = typeof project === 'string';
-  if (!projectOverridden) {
+  if (!projectOverridden || !project) {
     // We use the project name because it is very readable.
     // It may not work in all APIs and if it fails, we can switch from `System.TeamProject` to `System.TeamProjectId`.
-    project = tl.getVariable('System.TeamProject');
+    project = tl.getVariable('System.TeamProject')!;
     tl.debug(`No custom project provided; Running update for current project.`);
   } else {
     tl.debug(`Custom project provided; Running update for specified project.`);
@@ -74,15 +74,15 @@ export function getTaskInputs(): TaskInputs {
   if (projectOverridden && !repositoryOverridden) {
     throw new Error(`Target repository must be provided when target project is overridden`);
   }
-  if (!repositoryOverridden) {
-    repository = tl.getVariable('Build.Repository.Name');
+  if (!repositoryOverridden || !repository) {
+    repository = tl.getVariable('Build.Repository.Name')!;
     tl.debug(`No custom repository provided; Running update for local repository.`);
   } else {
     tl.debug(`Custom repository provided; Running update for remote repository.`);
   }
 
   const organisationUrl = tl.getVariable('System.TeamFoundationCollectionUri')!;
-  const urlParts = extractRepositoryUrl({ organisationUrl, project: project!, repository: repository! });
+  const urlParts = extractRepositoryUrl({ organisationUrl, project, repository });
 
   // Prepare the access credentials
   const githubAccessToken = getGithubAccessToken();

--- a/packages/core/src/azure/client/client-pull-requests.ts
+++ b/packages/core/src/azure/client/client-pull-requests.ts
@@ -26,10 +26,13 @@ export class PullRequestsClient extends BaseAzureDevOpsClient {
   ): Promise<AzdoPullRequest[] | undefined> {
     const response = await this.client
       .get<AzdoResponse<AzdoPullRequest[]>>(
-        this.makeUrl(`${projectIdOrName}/_apis/git/repositories/${repositoryIdOrName}/pullrequests`, {
-          'searchCriteria.creatorId': creatorId,
-          'searchCriteria.status': status,
-        }),
+        this.makeUrl(
+          `${encodeURIComponent(projectIdOrName)}/_apis/git/repositories/${encodeURIComponent(repositoryIdOrName)}/pullrequests`,
+          {
+            'searchCriteria.creatorId': creatorId,
+            'searchCriteria.status': status,
+          },
+        ),
       )
       .json();
     return response?.value;
@@ -42,7 +45,9 @@ export class PullRequestsClient extends BaseAzureDevOpsClient {
   ): Promise<AzdoPullRequest | undefined> {
     return await this.client
       .get<AzdoPullRequest>(
-        this.makeUrl(`${projectIdOrName}/_apis/git/repositories/${repositoryIdOrName}/pullrequests/${pullRequestId}`),
+        this.makeUrl(
+          `${encodeURIComponent(projectIdOrName)}/_apis/git/repositories/${encodeURIComponent(repositoryIdOrName)}/pullrequests/${pullRequestId}`,
+        ),
       )
       .json();
   }
@@ -54,7 +59,9 @@ export class PullRequestsClient extends BaseAzureDevOpsClient {
   ): Promise<AzdoPullRequest> {
     return await this.client
       .post<AzdoPullRequest>(
-        this.makeUrl(`${projectIdOrName}/_apis/git/repositories/${repositoryIdOrName}/pullrequests`),
+        this.makeUrl(
+          `${encodeURIComponent(projectIdOrName)}/_apis/git/repositories/${encodeURIComponent(repositoryIdOrName)}/pullrequests`,
+        ),
         { json: pr },
       )
       .json();
@@ -68,7 +75,9 @@ export class PullRequestsClient extends BaseAzureDevOpsClient {
   ): Promise<AzdoPullRequest> {
     return await this.client
       .patch<AzdoPullRequest>(
-        this.makeUrl(`${projectIdOrName}/_apis/git/repositories/${repositoryIdOrName}/pullrequests/${pullRequestId}`),
+        this.makeUrl(
+          `${encodeURIComponent(projectIdOrName)}/_apis/git/repositories/${encodeURIComponent(repositoryIdOrName)}/pullrequests/${pullRequestId}`,
+        ),
         { json: pr },
       )
       .json();
@@ -82,7 +91,7 @@ export class PullRequestsClient extends BaseAzureDevOpsClient {
     const response = await this.client
       .get<AzdoResponse<AzdoProperties>>(
         this.makeUrl(
-          `${projectIdOrName}/_apis/git/repositories/${repositoryIdOrName}/pullrequests/${pullRequestId}/properties`,
+          `${encodeURIComponent(projectIdOrName)}/_apis/git/repositories/${encodeURIComponent(repositoryIdOrName)}/pullrequests/${pullRequestId}/properties`,
         ),
       )
       .json();
@@ -133,7 +142,7 @@ export class PullRequestsClient extends BaseAzureDevOpsClient {
     return await this.client
       .put<AzdoIdentityRefWithVote>(
         this.makeUrl(
-          `${projectIdOrName}/_apis/git/repositories/${repositoryIdOrName}/pullrequests/${pullRequestId}/reviewers/${userId}`,
+          `${encodeURIComponent(projectIdOrName)}/_apis/git/repositories/${encodeURIComponent(repositoryIdOrName)}/pullrequests/${pullRequestId}/reviewers/${userId}`,
           // API version 7.1 is required to use the 'isReapprove' parameter
           // See: https://learn.microsoft.com/en-us/rest/api/azure/devops/git/pull-request-reviewers/create-pull-request-reviewer?view=azure-devops-rest-7.1&tabs=HTTP#request-body
           //      https://learn.microsoft.com/en-us/azure/devops/integrate/concepts/rest-api-versioning?view=azure-devops#supported-versions
@@ -166,7 +175,9 @@ export class PullRequestsClient extends BaseAzureDevOpsClient {
   ): Promise<AzdoPullRequest> {
     return await this.client
       .patch<AzdoPullRequest>(
-        this.makeUrl(`${projectIdOrName}/_apis/git/repositories/${repositoryIdOrName}/pullrequests/${pullRequestId}`),
+        this.makeUrl(
+          `${encodeURIComponent(projectIdOrName)}/_apis/git/repositories/${encodeURIComponent(repositoryIdOrName)}/pullrequests/${pullRequestId}`,
+        ),
         {
           json: {
             status: 'abandoned',
@@ -189,7 +200,7 @@ export class PullRequestsClient extends BaseAzureDevOpsClient {
     const response = await this.client
       .get<AzdoResponse<AzdoGitCommitRef[]>>(
         this.makeUrl(
-          `${projectIdOrName}/_apis/git/repositories/${repositoryIdOrName}/pullrequests/${pullRequestId}/commits`,
+          `${encodeURIComponent(projectIdOrName)}/_apis/git/repositories/${encodeURIComponent(repositoryIdOrName)}/pullrequests/${pullRequestId}/commits`,
         ),
       )
       .json();
@@ -209,7 +220,7 @@ export class PullRequestsClient extends BaseAzureDevOpsClient {
     return await this.client
       .post<AzdoPullRequestCommentThread>(
         this.makeUrl(
-          `${projectIdOrName}/_apis/git/repositories/${repositoryIdOrName}/pullrequests/${pullRequestId}/threads`,
+          `${encodeURIComponent(projectIdOrName)}/_apis/git/repositories/${encodeURIComponent(repositoryIdOrName)}/pullrequests/${pullRequestId}/threads`,
         ),
         { json: thread },
       )

--- a/packages/core/src/azure/url-parts.test.ts
+++ b/packages/core/src/azure/url-parts.test.ts
@@ -92,9 +92,9 @@ describe('extractRepositoryUrl', () => {
     });
     expect(url.hostname).toBe('dev.azure.com');
     expect(url['api-endpoint']).toBe('https://dev.azure.com/');
-    expect(url.project).toBe('prj%201');
-    expect(url.repository).toBe('repo%201');
-    expect(url['repository-slug']).toBe('contoso/prj%201/_git/repo%201');
+    expect(url.project).toBe('prj 1'); // Stored raw for client methods to encode
+    expect(url.repository).toBe('repo 1'); // Stored raw for client methods to encode
+    expect(url['repository-slug']).toBe('contoso/prj%201/_git/repo%201'); // Slug is encoded for display
   });
 
   it('works for azure devops domain without trailing slash', () => {
@@ -109,5 +109,18 @@ describe('extractRepositoryUrl', () => {
     expect(url.project).toBe('prj1');
     expect(url.repository).toBe('repo1');
     expect(url['repository-slug']).toBe('contoso/prj1/_git/repo1');
+  });
+
+  it('handles already-encoded project and repository names to prevent double-encoding', () => {
+    const url = extractRepositoryUrl({
+      organisationUrl: 'https://dev.azure.com/contoso/',
+      project: 'Markt%20-%20Project', // already encoded input
+      repository: 'repo%201', // already encoded input
+    });
+    expect(url.hostname).toBe('dev.azure.com');
+    expect(url['api-endpoint']).toBe('https://dev.azure.com/');
+    expect(url.project).toBe('Markt - Project'); // Decoded to raw value
+    expect(url.repository).toBe('repo 1'); // Decoded to raw value
+    expect(url['repository-slug']).toBe('contoso/Markt%20-%20Project/_git/repo%201'); // Slug re-encoded
   });
 });

--- a/packages/core/src/azure/url-parts.ts
+++ b/packages/core/src/azure/url-parts.ts
@@ -22,12 +22,18 @@ export type AzureDevOpsOrganizationUrl = {
 };
 
 export type AzureDevOpsProjectUrl = AzureDevOpsOrganizationUrl & {
-  /** Project ID or Name */
+  /**
+   * Project ID or Name.
+   * This value is not URL-encoded, clients must encode it when constructing URLs.
+   */
   project: string;
 };
 
 export type AzureDevOpsRepositoryUrl = AzureDevOpsProjectUrl & {
-  /** Repository ID or Name */
+  /**
+   * Repository ID or Name.
+   * This value is not URL-encoded, clients must encode it when constructing URLs.
+   */
   repository: string;
 
   /** Slug of the repository e.g. `contoso/prj1/_git/repo1`, `tfs/contoso/prj1/_git/repo1` */
@@ -73,11 +79,12 @@ export function extractProjectUrl({
   project: string;
 }): AzureDevOpsProjectUrl {
   const extracted = extractOrganizationUrl({ organisationUrl });
-  const escapedProject = encodeURI(project); // encode special characters like spaces
+  // Decode to handle already-encoded inputs, store raw for client methods to encode
+  const decodedProject = decodeURIComponent(project);
 
   return {
     ...extracted,
-    project: escapedProject,
+    project: decodedProject,
   };
 }
 
@@ -91,14 +98,16 @@ export function extractRepositoryUrl({
   repository: string;
 }): AzureDevOpsRepositoryUrl {
   const extracted = extractProjectUrl({ organisationUrl, project });
-  const { organisation, 'virtual-directory': virtualDirectory, project: escapedProject } = extracted;
+  const { organisation, 'virtual-directory': virtualDirectory, project: decodedProject } = extracted;
 
-  const escapedRepository = encodeURI(repository); // encode special characters like spaces
-  const repoSlug = `${virtualDirectory ? `${virtualDirectory}/` : ''}${organisation}/${escapedProject}/_git/${escapedRepository}`;
+  // Decode to handle already-encoded inputs, store raw for client methods to encode
+  const decodedRepository = decodeURIComponent(repository);
+  // For the slug, encode since it's used in display/logging contexts
+  const repoSlug = `${virtualDirectory ? `${virtualDirectory}/` : ''}${organisation}/${encodeURI(decodedProject)}/_git/${encodeURI(decodedRepository)}`;
 
   return {
     ...extracted,
-    repository: escapedRepository,
+    repository: decodedRepository,
     'repository-slug': repoSlug,
   };
 }


### PR DESCRIPTION
Refactor URL handling in Azure DevOps client or prevent double encoding of project and repository names

Fixes: #2339 