### PR TITLE
Only output logs from proxy if in debug mode

### DIFF
--- a/.changeset/jolly-lights-sell.md
+++ b/.changeset/jolly-lights-sell.md
@@ -1,0 +1,5 @@
+---
+"@paklo/core": minor
+---
+
+Only output logs from proxy if in debug mode. This is meant to reduce unnecessary logs output in Azure pipelines hence avoid low/no disk space errors.

--- a/packages/runner/src/proxy.ts
+++ b/packages/runner/src/proxy.ts
@@ -81,7 +81,13 @@ export class ProxyBuilder {
       stdout: true,
       stderr: true,
     });
-    container.modem.demuxStream(stream, this.debug ? outStream('  proxy') : nullStream, errStream('  proxy'));
+    container.modem.demuxStream(
+      stream,
+      // proxy generates lots of logs that we do not need unless debugging
+      // this should save on disk space in agents running Azure pipelines
+      this.debug ? outStream('  proxy') : nullStream,
+      this.debug ? errStream('  proxy') : nullStream,
+    );
 
     const url = async (): Promise<string> => {
       const containerInfo = await container.inspect();


### PR DESCRIPTION
This is meant to reduce unnecessary logs output in Azure pipelines hence avoid low/no disk space errors.

Fixes: #2128 