### PR TITLE
Enable Partial PreRendering (PPR) with `cacheComponents`

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -6,6 +6,7 @@ const config: NextConfig = {
   reactStrictMode: true,
   reactCompiler: true,
   typedRoutes: true,
+  cacheComponents: true,
   logging: { fetches: { fullUrl: true } }, // allows us to see cache behavior for fetches
   images: {
     formats: ['image/avif', 'image/webp'],

--- a/apps/web/src/app/(marketing)/layout.tsx
+++ b/apps/web/src/app/(marketing)/layout.tsx
@@ -94,7 +94,9 @@ async function Footer() {
     { name: 'LinkedIn', href: socials.linkedin.url, icon: LinkedInLogo },
   ];
 
+  // https://nextjs.org/docs/messages/next-prerender-current-time-client#cache-the-time-in-a-server-component
   async function getCurrentYear() {
+    'use cache';
     return new Date().getFullYear();
   }
 

--- a/apps/web/src/app/(marketing)/page.tsx
+++ b/apps/web/src/app/(marketing)/page.tsx
@@ -7,11 +7,13 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Item, ItemContent, ItemDescription, ItemMedia, ItemTitle } from '@/components/ui/item';
+import { enableHomePageStats } from '@/lib/flags';
 import { extensions } from '@/site-config';
 import { faqs, features, pricing } from './page.data';
 
 export default async function HomePage() {
-  const { installations, runs } = await getHomePageStats('90d');
+  const query = await enableHomePageStats();
+  const { installations, runs } = await getHomePageStats('90d', query);
   const installationsTruncated = Math.floor(installations / 100) * 100; // 4458 -> 4400
 
   const stats = runs

--- a/apps/web/src/app/loading.tsx
+++ b/apps/web/src/app/loading.tsx
@@ -1,0 +1,6 @@
+export default function Loading() {
+  // need this for <TooltipProvider> and <ThemeProvider> to work with cacheComponents
+  // it also works when a loading.tsx is not present at any level
+  // ideally, we should have skeletons in all the other layers
+  return null;
+}


### PR DESCRIPTION
Relatively new and meant to speed things up and cache things we seldom fetch like stats.

The key change is adding suspense to handle asynchronous loading of data (from cache or db). To handle this globally, added a dummy/null suspense at the root. Besides it handling suspense for all routes, it particularly solves issues for `NextThemesProvider`, `TooltipProvider`, and `TimeAgo`.

Docs:
- [caching and revalidating](https://nextjs.org/docs/app/getting-started/caching-and-revalidating)
- [cache components](https://nextjs.org/docs/app/getting-started/cache-components)