### PR TITLE
`conda` ecosystem graduated to stable

### DIFF
--- a/.changeset/goofy-goats-care.md
+++ b/.changeset/goofy-goats-care.md
@@ -1,0 +1,6 @@
+---
+"@paklo/core": patch
+---
+
+`conda` ecosystem graduated to stable
+Official changelog: https://github.blog/changelog/2025-12-16-conda-ecosystem-support-for-dependabot-now-generally-available/

--- a/packages/core/src/dependabot/config.test.ts
+++ b/packages/core/src/dependabot/config.test.ts
@@ -639,11 +639,7 @@ describe('Duplicate update configuration detection', () => {
 });
 
 describe('Beta ecosystems validation', () => {
-  it.each([
-    'bazel',
-    'conda',
-    'opentofu',
-  ])('Should reject %s when enable-beta-ecosystems is not set', async (ecosystem) => {
+  it.each(['bazel', 'opentofu'])('Should reject %s when enable-beta-ecosystems is not set', async (ecosystem) => {
     const config = {
       version: 2,
       updates: [
@@ -660,7 +656,7 @@ describe('Beta ecosystems validation', () => {
     );
   });
 
-  it.each(['bazel', 'conda', 'opentofu'])('Should allow %s when enable-beta-ecosystems is true', async (ecosystem) => {
+  it.each(['bazel', 'opentofu'])('Should allow %s when enable-beta-ecosystems is true', async (ecosystem) => {
     const config = {
       version: 2,
       'enable-beta-ecosystems': true,

--- a/packages/core/src/dependabot/config.ts
+++ b/packages/core/src/dependabot/config.ts
@@ -327,7 +327,7 @@ export const DependabotConfigSchema = z
     }
 
     // ensure that the ecosystems in beta are only used when 'enable-beta-ecosystems' is true
-    const betaEcosystems: PackageEcosystem[] = ['bazel', 'conda', 'opentofu'];
+    const betaEcosystems: PackageEcosystem[] = ['bazel', 'opentofu'];
     if (!value['enable-beta-ecosystems']) {
       for (const update of value.updates) {
         if (betaEcosystems.includes(update['package-ecosystem'])) {


### PR DESCRIPTION
Official changelog: https://github.blog/changelog/2025-12-16-conda-ecosystem-support-for-dependabot-now-generally-available/