### PR TITLE
`opentofu` ecosystem graduated to stable

### DIFF
--- a/.changeset/moody-bananas-retire.md
+++ b/.changeset/moody-bananas-retire.md
@@ -1,0 +1,6 @@
+---
+"@paklo/core": patch
+---
+
+`opentofu` ecosystem graduated to stable
+Official changelog: https://github.blog/changelog/2025-12-16-dependabot-version-updates-now-support-opentofu

--- a/packages/core/src/dependabot/config.ts
+++ b/packages/core/src/dependabot/config.ts
@@ -178,7 +178,7 @@ export const PackageEcosystemSchema = z.enum([
   'maven',
   'npm',
   'nuget',
-  'opentofu', // in beta as of 2025-Nov-17
+  'opentofu',
   'pip',
   'pip-compile', // alias mapped to 'pip'
   'pipenv', // alias mapped to 'pip'
@@ -261,7 +261,7 @@ export const DependabotMultiEcosystemGroupSchema = z.object({
 export type DependabotMultiEcosystemGroup = z.infer<typeof DependabotMultiEcosystemGroupSchema>;
 
 /* Ecosystems that are currently in beta */
-export const BETA_ECOSYSTEMS: PackageEcosystem[] = ['opentofu'];
+export const BETA_ECOSYSTEMS: PackageEcosystem[] = [];
 
 /**
  * Represents the dependabot.yaml configuration file options.


### PR DESCRIPTION
Official changelog: https://github.blog/changelog/2025-12-16-dependabot-version-updates-now-support-opentofu