### PR TITLE
Refactor repository update handling to store dependencies directly in MongoDB

### DIFF
--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -322,9 +322,6 @@ model RepositoryUpdate {
   nextUpdateJobAt DateTime
   files           String[]
 
-  /// [DependabotPersistedDep]
-  deps Json[]
-
   @@unique([repositoryId, ecosystem, directoryKey])
   @@index([repositoryId])
   @@map("repository_update")

--- a/apps/web/src/app/api/crons/[...all]/route.ts
+++ b/apps/web/src/app/api/crons/[...all]/route.ts
@@ -53,7 +53,6 @@ app.get('/trigger-update-jobs', async (context) => {
   const dueRepositoryUpdates = await prisma.repositoryUpdate.findMany({
     where: { enabled: true, nextUpdateJobAt: { lte: new Date() } },
     orderBy: { nextUpdateJobAt: 'asc' },
-    omit: { deps: true },
     take: 500,
   });
 

--- a/apps/web/src/lib/mongodb.ts
+++ b/apps/web/src/lib/mongodb.ts
@@ -1,3 +1,4 @@
+import { PackageEcosystemSchema } from '@paklo/core/dependabot';
 import { UsageTelemetryRequestDataSchema } from '@paklo/core/usage';
 import { type Document, MongoClient } from 'mongodb';
 import { z } from 'zod';
@@ -25,6 +26,7 @@ export async function closeMongoClient() {
 type EnsureDocumentMap<T extends Record<string, Document>> = T;
 type Collections = EnsureDocumentMap<{
   usage_telemetry: UsageTelemetry;
+  repository_update_dependencies: RepositoryUpdateDependencies;
   // add future collections here
 }>;
 
@@ -49,5 +51,17 @@ export const UsageTelemetrySchema = z.object({
   ...UsageTelemetryRequestDataSchema.omit({ id: true }).shape,
 });
 export type UsageTelemetry = z.infer<typeof UsageTelemetrySchema>;
+
+export const RepositoryUpdateDependenciesSchema = z.object({
+  _id: z.string(),
+  ecosystem: PackageEcosystemSchema,
+  deps: z
+    .object({
+      name: z.string(),
+      version: z.string().nullish(),
+    })
+    .array(),
+});
+export type RepositoryUpdateDependencies = z.infer<typeof RepositoryUpdateDependenciesSchema>;
 
 export type { AnyBulkWriteOperation, Filter } from 'mongodb';

--- a/apps/web/src/lib/prisma.ts
+++ b/apps/web/src/lib/prisma.ts
@@ -38,6 +38,4 @@ export type {
   JsonValue,
 } from '@/../.generated/prisma/runtime/library';
 
-export type DependabotPersistedDep = PrismaJson.DependabotPersistedDep;
-
 if (process.env.NODE_ENV === 'development') globalForPrisma.prisma = prisma;

--- a/apps/web/src/prisma-json.d.ts
+++ b/apps/web/src/prisma-json.d.ts
@@ -15,10 +15,6 @@ import type { Period as ImportedPeriod } from '@/lib/period';
 
 declare global {
   namespace PrismaJson {
-    type DependabotPersistedDep = {
-      name: string;
-      version?: string;
-    };
     type DependabotPersistedPr = ImportedDependabotPersistedPr;
     type DependabotConfig = ImportedDependabotConfig;
     type DependabotJobConfig = ImportedDependabotJobConfig;

--- a/apps/web/src/workflows/jobs/trigger.ts
+++ b/apps/web/src/workflows/jobs/trigger.ts
@@ -139,7 +139,6 @@ async function getOrCreateUpdateJobs(options: GetOrCreateUpdateJobOptions): Prom
       id: hasRequestedSpecificUpdates ? { in: repositoryUpdateIds } : undefined,
       repositoryId: hasRequestedSpecificUpdates ? undefined : repositoryId,
     },
-    omit: { deps: true },
   });
 
   let config: DependabotConfig | undefined;


### PR DESCRIPTION
This is now done without prisma and independently. Given the size of the data, this is a better approach and hence no omit calls. Also added unique checks for deps in SBOM route.