### PR TITLE
Remove `fetch_files` command.

### DIFF
--- a/.changeset/modern-cups-drop.md
+++ b/.changeset/modern-cups-drop.md
@@ -1,0 +1,8 @@
+---
+"@paklo/runner": minor
+---
+
+Remove `fetch_files` command.
+In <https://github.com/dependabot/dependabot-core/pull/13275> the `fetch_files` command was made a no-op, and it does not need to be called.
+Also cleaned up environment variables that are not used as a result.
+Copied from: <https://github.com/github/dependabot-action/pull/1550>

--- a/apps/web/src/workflows/jobs/trigger.ts
+++ b/apps/web/src/workflows/jobs/trigger.ts
@@ -20,8 +20,6 @@ import {
   extractUpdaterSha,
   JOB_INPUT_FILENAME,
   JOB_INPUT_PATH,
-  JOB_OUTPUT_FILENAME,
-  JOB_OUTPUT_PATH,
   PROXY_IMAGE_NAME,
   ProxyBuilder,
   REPO_CONTENTS_PATH,
@@ -478,8 +476,6 @@ export async function createAndStartJobResources({
             { name: 'DEPENDABOT_JOB_TOKEN', value: '' },
             { name: 'DEPENDABOT_JOB_PATH', value: `${JOB_INPUT_PATH}/${JOB_INPUT_FILENAME}` },
             { name: 'DEPENDABOT_OPEN_TIMEOUT_IN_SECONDS', value: '15' },
-            // not using the file share because we are not consuming the output yet
-            { name: 'DEPENDABOT_OUTPUT_PATH', value: `${JOB_OUTPUT_PATH}/${JOB_OUTPUT_FILENAME}` },
             // not using the file share because we do not need to clone repos there
             { name: 'DEPENDABOT_REPO_CONTENTS_PATH', value: REPO_CONTENTS_PATH },
             { name: 'DEPENDABOT_API_URL', value: apiUrl },
@@ -488,7 +484,6 @@ export async function createAndStartJobResources({
             { name: 'HTTP_PROXY', value: proxyUrl },
             { name: 'https_proxy', value: proxyUrl },
             { name: 'HTTPS_PROXY', value: proxyUrl },
-            { name: 'UPDATER_ONE_CONTAINER', value: '1' },
 
             // enable or disable connectivity check based on feature flag
             ...((await enableDependabotConnectivityCheck())

--- a/packages/runner/src/container-service.ts
+++ b/packages/runner/src/container-service.ts
@@ -47,7 +47,7 @@ export const ContainerService = {
         // Then run the dependabot commands as dependabot user
         const dependabotCommands = [
           'mkdir -p /home/dependabot/dependabot-updater/output',
-          '$DEPENDABOT_HOME/dependabot-updater/bin/run fetch_files',
+          // 'fetch_files' command removed as it is now a no-op
         ];
 
         if (command === 'graph') {

--- a/packages/runner/src/updater-builder.ts
+++ b/packages/runner/src/updater-builder.ts
@@ -9,8 +9,6 @@ import type { JobParameters } from './params';
 import type { Proxy } from './proxy';
 import { extractUpdaterSha } from './utils';
 
-export const JOB_OUTPUT_FILENAME = 'output.json';
-export const JOB_OUTPUT_PATH = '/home/dependabot/dependabot-updater/output';
 export const JOB_INPUT_FILENAME = 'job.json';
 export const JOB_INPUT_PATH = `/home/dependabot/dependabot-updater`;
 export const REPO_CONTENTS_PATH = '/home/dependabot/dependabot-updater/repo';
@@ -40,7 +38,6 @@ export class UpdaterBuilder {
       `DEPENDABOT_JOB_TOKEN=`,
       `DEPENDABOT_JOB_PATH=${JOB_INPUT_PATH}/${JOB_INPUT_FILENAME}`,
       `DEPENDABOT_OPEN_TIMEOUT_IN_SECONDS=15`,
-      `DEPENDABOT_OUTPUT_PATH=${JOB_OUTPUT_PATH}/${JOB_OUTPUT_FILENAME}`,
       `DEPENDABOT_REPO_CONTENTS_PATH=${REPO_CONTENTS_PATH}`,
       `DEPENDABOT_API_URL=${this.jobParams.dependabotApiDockerUrl}`,
       `SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt`,
@@ -48,7 +45,6 @@ export class UpdaterBuilder {
       `HTTP_PROXY=${proxyUrl}`,
       `https_proxy=${proxyUrl}`,
       `HTTPS_PROXY=${proxyUrl}`,
-      `UPDATER_ONE_CONTAINER=1`,
       `ENABLE_CONNECTIVITY_CHECK=${process.env.DEPENDABOT_ENABLE_CONNECTIVITY_CHECK || '1'}`,
 
       // for updates relying on .NET (e.g. NuGet) and running on macOS (e.g. dev laptop or local MacMini),


### PR DESCRIPTION
In https://github.com/dependabot/dependabot-core/pull/13275 the `fetch_files` command was made a no-op, and it does not need to be called. Also cleaned up environment variables that are not used as a result.

Copied from: https://github.com/github/dependabot-action/pull/1550