### PR TITLE
Simplify CLI with repository URL and provider option

### DIFF
--- a/.changeset/petite-jokes-fall.md
+++ b/.changeset/petite-jokes-fall.md
@@ -1,0 +1,5 @@
+---
+"@paklo/cli": minor
+---
+
+Change CLI commands to take repository URL directly with a provider hence allow for other providers

--- a/.changeset/sour-carpets-cut.md
+++ b/.changeset/sour-carpets-cut.md
@@ -1,0 +1,5 @@
+---
+"@paklo/core": minor
+---
+
+Update URL parsing to enhace org extraction and allow repository extract from a repository url directly

--- a/apps/web/content/docs/cli.md
+++ b/apps/web/content/docs/cli.md
@@ -43,10 +43,9 @@ First, validate your `dependabot.yml` file:
 
 ```bash
 paklo validate \
-  --organization-url https://dev.azure.com/my-org \
-  --project my-project \
-  --repository my-repo \
-  --git-token $AZDO_TOKEN
+  --provider azure \
+  --repository-url https://dev.azure.com/my-org/my-project/_git/my-repo \
+  --git-token $GIT_ACCESS_TOKEN
 ```
 
 ### 2. Run Updates
@@ -55,10 +54,9 @@ Execute dependency updates:
 
 ```bash
 paklo run \
-  --organization-url https://dev.azure.com/my-org \
-  --project my-project \
-  --repository my-repo \
-  --git-token $AZDO_TOKEN \
+  --provider azure \
+  --repository-url https://dev.azure.com/my-org/my-project/_git/my-repo \
+  --git-token $GIT_ACCESS_TOKEN \
   --github-token $GITHUB_TOKEN
 ```
 
@@ -82,19 +80,17 @@ paklo validate [options]
 
 **Required Options:**
 
-- `--organization-url <URL>` - Azure DevOps organization URL (e.g., `https://dev.azure.com/my-org`)
-- `--project <PROJECT>` - Project name or ID
-- `--repository <REPOSITORY>` - Repository name or ID
-- `--git-token <TOKEN>` - Azure DevOps Personal Access Token
+- `--provider <PROVIDER>` - Repository provider (currently only `azure` is supported)
+- `--repository-url <URL>` - Repository URL (e.g., `https://dev.azure.com/my-org/project/_git/repo`)
+- `--git-token <GIT_TOKEN>` - Git provider access token
 
 **Example:**
 
 ```bash
 paklo validate \
-  --organization-url https://dev.azure.com/contoso \
-  --project contoso-project \
-  --repository web-app \
-  --git-token $AZDO_PAT
+  --provider azure \
+  --repository-url https://dev.azure.com/my-org/my-project/_git/my-repo \
+  --git-token $GIT_ACCESS_TOKEN
 ```
 
 ### run
@@ -107,10 +103,9 @@ paklo run [options]
 
 **Required Options:**
 
-- `--organization-url <URL>` - Azure DevOps organization URL
-- `--project <PROJECT>` - Project name or ID
-- `--repository <REPOSITORY>` - Repository name or ID
-- `--git-token <TOKEN>` - Azure DevOps Personal Access Token
+- `--provider <PROVIDER>` - Repository provider (currently only `azure` is supported)
+- `--repository-url <URL>` - Repository URL
+- `--git-token <GIT_TOKEN>` - Git provider access token
 
 **Optional Options:**
 
@@ -139,10 +134,9 @@ paklo run [options]
 
 ```bash
 paklo run \
-  --organization-url https://dev.azure.com/contoso \
-  --project contoso-project \
-  --repository web-app \
-  --git-token $AZDO_PAT \
+  --provider azure \
+  --repository-url https://dev.azure.com/my-org/my-project/_git/my-repo \
+  --git-token $GIT_ACCESS_TOKEN \
   --github-token $GITHUB_TOKEN \
   --auto-approve \
   --set-auto-complete \

--- a/apps/web/content/docs/custom-ca-certificates.md
+++ b/apps/web/content/docs/custom-ca-certificates.md
@@ -57,10 +57,9 @@ export CUSTOM_CA_PATH=/etc/ssl/certs/company-ca.crt
 
 # Run Paklo CLI
 paklo run \
-  --organization-url https://dev.azure.com/my-org \
-  --project my-project \
-  --repository my-repo \
-  --git-token $GIT_TOKEN \
+  --provider azure
+  --repository-url https://dev.azure.com/my-org/my-project/_git/my-repo \
+  --git-token $GIT_ACCESS_TOKEN \
   --debug
 ```
 
@@ -77,10 +76,9 @@ export CUSTOM_CA_PATH=/etc/ssl/certs/company-root-ca.crt
 
 # Run Paklo
 paklo run \
-  --organization-url https://dev.azure.com/my-org \
-  --project my-project \
-  --repository my-repo \
-  --git-token $GIT_TOKEN
+  --provider azure
+  --repository-url https://dev.azure.com/my-org/my-project/_git/my-repo \
+  --git-token $GIT_ACCESS_TOKEN
 ```
 
 ### Example: Corporate Proxy with SSL Inspection
@@ -95,7 +93,7 @@ export NODE_EXTRA_CA_CERTS=/usr/local/share/ca-certificates/proxy-ca.crt
 export https_proxy=http://proxy.company.com:8080
 export http_proxy=http://proxy.company.com:8080
 
-paklo run --organization-url https://dev.azure.com/my-org ...
+paklo run --provider azure --repository-url https://dev.azure.com/my-org/my-project/_git/my-repo ...
 ```
 
 ## Usage with Azure DevOps Extension

--- a/apps/web/content/docs/experiments.md
+++ b/apps/web/content/docs/experiments.md
@@ -33,10 +33,9 @@ Use the `--experiments` option:
 
 ```bash
 paklo run \
-  --organization-url https://dev.azure.com/my-org \
-  --project my-project \
-  --repository my-repo \
-  --git-token $GIT_TOKEN \
+  --provider azure
+  --repository-url https://dev.azure.com/my-org/my-project/_git/my-repo \
+  --git-token $GIT_ACCESS_TOKEN \
   --experiments "tidy=true,vendor=true,goprivate=*"
 ```
 

--- a/apps/web/content/docs/security-advisories.md
+++ b/apps/web/content/docs/security-advisories.md
@@ -45,10 +45,9 @@ Provide the GitHub token via command-line option:
 
 ```bash
 paklo run \
-  --organization-url https://dev.azure.com/my-org \
-  --project my-project \
-  --repository my-repo \
-  --git-token $AZDO_TOKEN \
+  --provider azure
+  --repository-url https://dev.azure.com/my-org/my-project/_git/my-repo \
+  --git-token $GIT_ACCESS_TOKEN \
   --github-token $GITHUB_TOKEN
 ```
 
@@ -137,10 +136,9 @@ Use the `--security-advisories-file` option:
 
 ```bash
 paklo run \
-  --organization-url https://dev.azure.com/my-org \
-  --project my-project \
-  --repository my-repo \
-  --git-token $AZDO_TOKEN \
+  --provider azure
+  --repository-url https://dev.azure.com/my-org/my-project/_git/my-repo \
+  --git-token $GIT_ACCESS_TOKEN \
   --github-token $GITHUB_TOKEN \
   --security-advisories-file ./advisories.json
 ```

--- a/packages/core/src/azure/index.ts
+++ b/packages/core/src/azure/index.ts
@@ -3,9 +3,7 @@ export * from './config';
 export * from './events';
 export {
   type AzureDevOpsOrganizationUrl,
-  type AzureDevOpsProjectUrl,
   type AzureDevOpsRepositoryUrl,
   extractOrganizationUrl,
-  extractProjectUrl,
   extractRepositoryUrl,
 } from './url-parts';

--- a/packages/core/src/azure/url-parts.test.ts
+++ b/packages/core/src/azure/url-parts.test.ts
@@ -1,6 +1,74 @@
 import { describe, expect, it } from 'vitest';
 
-import { extractRepositoryUrl } from './url-parts';
+import { extractOrganizationUrl, extractRepositoryUrl } from './url-parts';
+
+describe('extractOrganizationUrl', () => {
+  it('works for old style devops url', () => {
+    const url = extractOrganizationUrl({ organizationUrl: 'https://contoso.visualstudio.com/' });
+    expect(url.hostname).toBe('dev.azure.com');
+    expect(url['api-endpoint']).toBe('https://dev.azure.com/');
+    expect(url['identity-api-url']).toEqual(new URL('https://vssps.dev.azure.com/contoso/'));
+    expect(url.organization).toBe('contoso');
+  });
+
+  it('works for azure devops domain', () => {
+    const url = extractOrganizationUrl({ organizationUrl: 'https://dev.azure.com/contoso/' });
+    expect(url.hostname).toBe('dev.azure.com');
+    expect(url['api-endpoint']).toBe('https://dev.azure.com/');
+    expect(url['identity-api-url']).toEqual(new URL('https://vssps.dev.azure.com/contoso/'));
+    expect(url.organization).toBe('contoso');
+  });
+
+  it('works for on-premise domain', () => {
+    const url = extractOrganizationUrl({ organizationUrl: 'https://server.domain.com/tfs/contoso/' });
+    expect(url.hostname).toBe('server.domain.com');
+    expect(url['api-endpoint']).toBe('https://server.domain.com/tfs/');
+    expect(url['identity-api-url']).toEqual(new URL('https://server.domain.com/tfs/contoso/'));
+    expect(url.organization).toBe('contoso');
+  });
+
+  it('works for on-premise domain with port', () => {
+    const url = extractOrganizationUrl({ organizationUrl: 'https://server.domain.com:8081/tfs/contoso/' });
+    expect(url.hostname).toBe('server.domain.com');
+    expect(url['api-endpoint']).toBe('https://server.domain.com:8081/tfs/');
+    expect(url.organization).toBe('contoso');
+  });
+
+  it('works for localhost', () => {
+    const url = extractOrganizationUrl({ organizationUrl: 'http://localhost:8080/contoso/' });
+    expect(url.hostname).toBe('localhost');
+    expect(url['api-endpoint']).toBe('http://localhost:8080/');
+    expect(url.organization).toBe('contoso');
+  });
+
+  it('works for organization url with virtual directory', () => {
+    const url = extractOrganizationUrl({ organizationUrl: 'https://server.domain.com/virtualDir/contoso/' });
+    expect(url.hostname).toBe('server.domain.com');
+    expect(url['api-endpoint']).toBe('https://server.domain.com/virtualDir/');
+    expect(url.organization).toBe('contoso');
+    expect(url['virtual-directory']).toBe('virtualDir');
+  });
+
+  it('works for localhost with virtual directory', () => {
+    const url = extractOrganizationUrl({ organizationUrl: 'http://localhost:8080/virtualDir/contoso/' });
+    expect(url.hostname).toBe('localhost');
+    expect(url['api-endpoint']).toBe('http://localhost:8080/virtualDir/');
+    expect(url.organization).toBe('contoso');
+    expect(url['virtual-directory']).toBe('virtualDir');
+  });
+
+  it('throws for invalid url', () => {
+    expect(() => extractOrganizationUrl({ organizationUrl: 'https://dev.azure.com/' })).toThrow(
+      "Error parsing organization from url: 'https://dev.azure.com/'.",
+    );
+  });
+
+  it('throws for invalid protocol', () => {
+    expect(() => extractOrganizationUrl({ organizationUrl: 'ftp://dev.azure.com/contoso/' })).toThrow(
+      "Invalid URL protocol: 'ftp'. Only 'http' and 'https' are supported.",
+    );
+  });
+});
 
 describe('extractRepositoryUrl', () => {
   it('works for old style devops url', () => {
@@ -71,19 +139,6 @@ describe('extractRepositoryUrl', () => {
     expect(url['repository-slug']).toBe('contoso/prj1/_git/repo1');
   });
 
-  it('works for project Uri', () => {
-    const url = extractRepositoryUrl({
-      organizationUrl: 'https://dev.azure.com/contoso/Core',
-      project: 'prj1',
-      repository: 'repo1',
-    });
-    expect(url.hostname).toBe('dev.azure.com');
-    expect(url['api-endpoint']).toBe('https://dev.azure.com/');
-    expect(url.project).toBe('prj1');
-    expect(url.repository).toBe('repo1');
-    expect(url['repository-slug']).toBe('contoso/prj1/_git/repo1');
-  });
-
   it('works for project or repository with spaces', () => {
     const url = extractRepositoryUrl({
       organizationUrl: 'https://dev.azure.com/contoso/',
@@ -97,20 +152,6 @@ describe('extractRepositoryUrl', () => {
     expect(url['repository-slug']).toBe('contoso/prj%201/_git/repo%201'); // Slug is encoded for display
   });
 
-  it('works for azure devops domain without trailing slash', () => {
-    const url = extractRepositoryUrl({
-      organizationUrl: 'https://dev.azure.com/contoso',
-      project: 'prj1',
-      repository: 'repo1',
-    });
-    expect(url.hostname).toBe('dev.azure.com');
-    expect(url['api-endpoint']).toBe('https://dev.azure.com/');
-    expect(url.organization).toBe('contoso');
-    expect(url.project).toBe('prj1');
-    expect(url.repository).toBe('repo1');
-    expect(url['repository-slug']).toBe('contoso/prj1/_git/repo1');
-  });
-
   it('handles already-encoded project and repository names to prevent double-encoding', () => {
     const url = extractRepositoryUrl({
       organizationUrl: 'https://dev.azure.com/contoso/',
@@ -122,5 +163,164 @@ describe('extractRepositoryUrl', () => {
     expect(url.project).toBe('Markt - Project'); // Decoded to raw value
     expect(url.repository).toBe('repo 1'); // Decoded to raw value
     expect(url['repository-slug']).toBe('contoso/Markt%20-%20Project/_git/repo%201'); // Slug re-encoded
+  });
+});
+
+describe('extractRepositoryUrl with repositoryUrl parameter', () => {
+  it('works for azure devops cloud url', () => {
+    const url = extractRepositoryUrl({
+      repositoryUrl: 'https://dev.azure.com/contoso/prj1/_git/repo1',
+    });
+    expect(url.hostname).toBe('dev.azure.com');
+    expect(url['api-endpoint']).toBe('https://dev.azure.com/');
+    expect(url['identity-api-url']).toEqual(new URL('https://vssps.dev.azure.com/contoso/'));
+    expect(url.organization).toBe('contoso');
+    expect(url.project).toBe('prj1');
+    expect(url.repository).toBe('repo1');
+    expect(url['repository-slug']).toBe('contoso/prj1/_git/repo1');
+  });
+
+  it('works for old style visualstudio.com url', () => {
+    const url = extractRepositoryUrl({
+      repositoryUrl: 'https://contoso.visualstudio.com/prj1/_git/repo1',
+    });
+    expect(url.hostname).toBe('dev.azure.com');
+    expect(url['api-endpoint']).toBe('https://dev.azure.com/');
+    expect(url['identity-api-url']).toEqual(new URL('https://vssps.dev.azure.com/contoso/'));
+    expect(url.organization).toBe('contoso');
+    expect(url.project).toBe('prj1');
+    expect(url.repository).toBe('repo1');
+    expect(url['repository-slug']).toBe('contoso/prj1/_git/repo1');
+  });
+
+  it('works for on-premise url with virtual directory', () => {
+    const url = extractRepositoryUrl({
+      repositoryUrl: 'https://server.domain.com/tfs/contoso/prj1/_git/repo1',
+    });
+    expect(url.hostname).toBe('server.domain.com');
+    expect(url['api-endpoint']).toBe('https://server.domain.com/tfs/');
+    expect(url['identity-api-url']).toEqual(new URL('https://server.domain.com/tfs/contoso/'));
+    expect(url.organization).toBe('contoso');
+    expect(url.project).toBe('prj1');
+    expect(url.repository).toBe('repo1');
+    expect(url['repository-slug']).toBe('tfs/contoso/prj1/_git/repo1');
+    expect(url['virtual-directory']).toBe('tfs');
+  });
+
+  it('works for on-premise url with port', () => {
+    const url = extractRepositoryUrl({
+      repositoryUrl: 'https://server.domain.com:8081/tfs/contoso/prj1/_git/repo1',
+    });
+    expect(url.hostname).toBe('server.domain.com');
+    expect(url['api-endpoint']).toBe('https://server.domain.com:8081/tfs/');
+    expect(url.organization).toBe('contoso');
+    expect(url.project).toBe('prj1');
+    expect(url.repository).toBe('repo1');
+    expect(url['repository-slug']).toBe('tfs/contoso/prj1/_git/repo1');
+    expect(url['virtual-directory']).toBe('tfs');
+  });
+
+  it('works for localhost', () => {
+    const url = extractRepositoryUrl({
+      repositoryUrl: 'http://localhost:8080/contoso/prj1/_git/repo1',
+    });
+    expect(url.hostname).toBe('localhost');
+    expect(url['api-endpoint']).toBe('http://localhost:8080/');
+    expect(url.organization).toBe('contoso');
+    expect(url.project).toBe('prj1');
+    expect(url.repository).toBe('repo1');
+    expect(url['repository-slug']).toBe('contoso/prj1/_git/repo1');
+  });
+
+  it('works for repository url with spaces', () => {
+    const url = extractRepositoryUrl({
+      repositoryUrl: 'https://dev.azure.com/contoso/prj%201/_git/repo%201',
+    });
+    expect(url.hostname).toBe('dev.azure.com');
+    expect(url['api-endpoint']).toBe('https://dev.azure.com/');
+    expect(url.organization).toBe('contoso');
+    expect(url.project).toBe('prj 1');
+    expect(url.repository).toBe('repo 1');
+    expect(url['repository-slug']).toBe('contoso/prj%201/_git/repo%201');
+  });
+
+  it('works for repository with forward slashes in name', () => {
+    const url = extractRepositoryUrl({
+      repositoryUrl: 'https://dev.azure.com/contoso/prj1/_git/team/repo1',
+    });
+    expect(url.hostname).toBe('dev.azure.com');
+    expect(url['api-endpoint']).toBe('https://dev.azure.com/');
+    expect(url.organization).toBe('contoso');
+    expect(url.project).toBe('prj1');
+    expect(url.repository).toBe('team/repo1');
+    expect(url['repository-slug']).toBe('contoso/prj1/_git/team/repo1');
+  });
+
+  it('works for localhost with virtual directory', () => {
+    const url = extractRepositoryUrl({
+      repositoryUrl: 'http://localhost:8080/tfs/contoso/prj1/_git/repo1',
+    });
+    expect(url.hostname).toBe('localhost');
+    expect(url['api-endpoint']).toBe('http://localhost:8080/tfs/');
+    expect(url.organization).toBe('contoso');
+    expect(url.project).toBe('prj1');
+    expect(url.repository).toBe('repo1');
+    expect(url['repository-slug']).toBe('tfs/contoso/prj1/_git/repo1');
+    expect(url['virtual-directory']).toBe('tfs');
+  });
+
+  it('works with query parameters in url', () => {
+    const url = extractRepositoryUrl({
+      repositoryUrl: 'https://dev.azure.com/contoso/prj1/_git/repo1?version=GBmain',
+    });
+    expect(url.hostname).toBe('dev.azure.com');
+    expect(url.organization).toBe('contoso');
+    expect(url.project).toBe('prj1');
+    expect(url.repository).toBe('repo1');
+  });
+
+  it('works with hash fragment in url', () => {
+    const url = extractRepositoryUrl({
+      repositoryUrl: 'https://dev.azure.com/contoso/prj1/_git/repo1#path=/README.md',
+    });
+    expect(url.hostname).toBe('dev.azure.com');
+    expect(url.organization).toBe('contoso');
+    expect(url.project).toBe('prj1');
+    expect(url.repository).toBe('repo1');
+  });
+
+  it('throws when _git is missing', () => {
+    expect(() =>
+      extractRepositoryUrl({
+        repositoryUrl: 'https://dev.azure.com/contoso/prj1/repo1',
+      }),
+    ).toThrow("Invalid repository URL: 'https://dev.azure.com/contoso/prj1/repo1'. URL must contain '/_git/'.");
+  });
+
+  it('throws when repository name is missing after _git', () => {
+    expect(() =>
+      extractRepositoryUrl({
+        repositoryUrl: 'https://dev.azure.com/contoso/prj1/_git/',
+      }),
+    ).toThrow(
+      "Invalid repository URL: 'https://dev.azure.com/contoso/prj1/_git/'. Repository name must follow '/_git/'.",
+    );
+  });
+
+  it('throws when repository name is missing after _git without trailing slash', () => {
+    expect(() =>
+      extractRepositoryUrl({
+        repositoryUrl: 'https://dev.azure.com/contoso/prj1/_git',
+      }),
+    ).toThrow("Invalid repository URL: 'https://dev.azure.com/contoso/prj1/_git'. URL must contain '/_git/'.");
+  });
+
+  it('works for nested repository names', () => {
+    const url = extractRepositoryUrl({
+      repositoryUrl: 'https://dev.azure.com/contoso/prj1/_git/team/sub/repo1',
+    });
+    expect(url.project).toBe('prj1');
+    expect(url.repository).toBe('team/sub/repo1');
+    expect(url['repository-slug']).toBe('contoso/prj1/_git/team/sub/repo1');
   });
 });


### PR DESCRIPTION
Replace separate organization/project/repository parameters with a single repository URL parameter in CLI commands. Add provider option to support future multi-provider scenarios.

Breaking Changes:
- CLI commands (run, validate) now require `--provider` and `--repository-url` instead of `--organization-url`, `--project`, `--repository`
- `extractProjectUrl` function removed from `@paklo/core` exports
- URL parsing now supports full repository URLs directly

Core Improvements:
- Simplified `extractRepositoryUrl` to handle both full repository URLs and component-based parameters.
- Enhanced `extractOrganizationUrl` to parse org/project/repo URLs (strips `_git` paths).
- Added protocol validation (http/https only)
- Reduced url-parts implementation to two clean functions with no helper duplication
- Test suite expanded with better coverage of repository URL parsing

Documentation Updates:
- Updated CLI examples

This change improves user experience by requiring fewer parameters and makes the API more flexible for future provider additions.