### PR TITLE
Match grouped PRs by group name instead of exact dependency list

### DIFF
--- a/packages/core/src/azure/client/utils.ts
+++ b/packages/core/src/azure/client/utils.ts
@@ -57,10 +57,22 @@ export function getPullRequestForDependencyNames(
   existingPullRequests: AzdoPrExtractedWithProperties[],
   packageManager: string,
   dependencyNames: string[],
+  dependencyGroupName?: string | null,
 ): AzdoPrExtractedWithProperties | undefined {
   return existingPullRequests
     .filter((pr) => filterPullRequestsByPackageManager(pr, packageManager))
-    .find((pr) => areEqual(getDependencyNames(parsePullRequestProps(pr)), dependencyNames));
+    .find((pr) => {
+      const parsedPr = parsePullRequestProps(pr);
+      const prGroupName = 'dependency-group-name' in parsedPr ? parsedPr['dependency-group-name'] : null;
+
+      // For grouped PRs: match by group name (dependencies can vary)
+      if (dependencyGroupName) {
+        return prGroupName === dependencyGroupName;
+      }
+
+      // For non-grouped PRs: match by exact dependency names
+      return !prGroupName && areEqual(getDependencyNames(parsedPr), dependencyNames);
+    });
 }
 
 export function getPullRequestChangedFiles(data: DependabotCreatePullRequest | DependabotUpdatePullRequest) {

--- a/packages/core/src/dependabot/job-builder.ts
+++ b/packages/core/src/dependabot/job-builder.ts
@@ -433,7 +433,6 @@ export function mapCredentials({
     });
   }
   if (registries) {
-    // TODO: only registries for the current update should be set
     // Required to authenticate with private package feeds when finding the latest version of dependencies.
     // The registries have already been worked on (see parseRegistries) so there is no need to do anything else.
     credentials.push(...Object.values(registries));

--- a/packages/runner/src/local/azure/server.ts
+++ b/packages/runner/src/local/azure/server.ts
@@ -213,6 +213,7 @@ export class AzureLocalDependabotServer extends LocalDependabotServer {
           existingPullRequests,
           packageManager,
           data['dependency-names'],
+          data['dependency-group']?.name,
         );
         if (!pullRequestToUpdate) {
           logger.error(


### PR DESCRIPTION
Fixes issue where Dependabot couldn't update grouped PRs when dependencies were added/removed from the group between updates.

The `getPullRequestForDependencyNames` function now accepts an optional `dependencyGroupName` parameter and uses different matching logic:
- Grouped PRs: Match by group name (dependencies can vary)
- Non-grouped PRs: Match by exact dependency names

This resolves the "Could not find pull request to update" errors.