### PR TITLE
Use node 24 in github workflows, and update docs

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: 'pnpm'
           registry-url: 'https://registry.npmjs.org'
 

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: 'pnpm'
 
       - name: Setup turborepo caching

--- a/.github/workflows/extension-azure.yml
+++ b/.github/workflows/extension-azure.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: 'pnpm'
 
       - name: Download deps

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/.github/workflows/update-container-manifest.yml
+++ b/.github/workflows/update-container-manifest.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: 'pnpm'
 
       - name: Setup turborepo caching

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: 'pnpm'
 
       - name: Setup turborepo caching

--- a/apps/web/content/docs/cli.md
+++ b/apps/web/content/docs/cli.md
@@ -9,7 +9,7 @@ The Paklo CLI is a powerful command-line tool for running Dependabot updates aga
 
 **Requirements:**
 
-- Node.js 22 or later
+- Node.js 24 or later
 - Docker (Docker Desktop on macOS/Windows, Docker Engine on Linux)
 
 ### Global Installation

--- a/apps/web/content/docs/contributing.md
+++ b/apps/web/content/docs/contributing.md
@@ -15,7 +15,7 @@ description: Guidelines for developing and submitting changes.
 
 ## Development Setup
 
-- Install [Node.js](https://nodejs.org) 22 or later
+- Install [Node.js](https://nodejs.org) 24 or later
 - Install [pnpm](https://pnpm.io)
 - Install [Docker](https://www.docker.com) (for CLI and extension development)
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -9,7 +9,7 @@ npm install -g @paklo/cli
 paklo --help
 ```
 
-**Requirements:** Node.js 22+ and Docker
+**Requirements:** Node.js 24+ and Docker
 
 ## Documentation
 


### PR DESCRIPTION
This aligns with the `packageManager` setting which is already 24