### PR TITLE
Add support for `groups.<name>.group-by: dependency-name`

### DIFF
--- a/.changeset/late-pugs-share.md
+++ b/.changeset/late-pugs-share.md
@@ -1,0 +1,6 @@
+---
+'@paklo/core': patch
+'@paklo/runner': patch
+---
+
+Add support for `groups.<name>.group-by: dependency-name` and use shared branch naming logic for grouped multi-directory updates.

--- a/apps/web/src/app/api/update_jobs/[[...all]]/route.ts
+++ b/apps/web/src/app/api/update_jobs/[[...all]]/route.ts
@@ -194,7 +194,9 @@ async function handlePrRequests(options: HandlePrRequestsOptions): Promise<boole
       const sourceBranch = getBranchNameForUpdate({
         packageEcosystem: update['package-ecosystem'],
         targetBranchName: targetBranch,
-        directory: update.directory || update.directories?.find((dir) => changedFiles[0]?.path?.startsWith(dir)),
+        directory: update.directory,
+        directories: update.directories,
+        changedFiles,
         dependencyGroupName: !Array.isArray(dependencies) ? dependencies['dependency-group-name'] : undefined,
         dependencies: !Array.isArray(dependencies) ? dependencies.dependencies : dependencies,
         separator: update['pull-request-branch-name']?.separator,

--- a/packages/core/src/dependabot/branch-name.test.ts
+++ b/packages/core/src/dependabot/branch-name.test.ts
@@ -103,6 +103,31 @@ describe('getBranchNameForUpdate', () => {
 
     expect(result).toBe(`dependabot-npm-main-some-deep-path-express-4.18.2`);
   });
+
+  it('omits the directory for grouped updates across multiple directories', () => {
+    const result = getBranchNameForUpdate({
+      packageEcosystem: 'npm',
+      targetBranchName: 'main',
+      directories: ['/frontend', '/admin-panel', '/mobile-app'],
+      dependencyGroupName: 'monorepo-dependencies',
+      changedFiles: [{ path: '/admin-panel/package.json' }, { path: '/mobile-app/package.json' }],
+      dependencies: [{ 'dependency-name': 'lodash', 'dependency-version': '4.17.21' }],
+    });
+
+    expect(result).toMatch(/^dependabot\/npm\/main\/monorepo-dependencies-[a-f0-9]{10}$/);
+  });
+
+  it('uses the matching directory for non-grouped multi-directory updates', () => {
+    const result = getBranchNameForUpdate({
+      packageEcosystem: 'npm',
+      targetBranchName: 'main',
+      directories: ['/frontend', '/admin-panel', '/mobile-app'],
+      changedFiles: [{ path: '/mobile-app/package.json' }],
+      dependencies: [{ 'dependency-name': 'lodash', 'dependency-version': '4.17.21' }],
+    });
+
+    expect(result).toBe('dependabot/npm/main/mobile-app/lodash-4.17.21');
+  });
 });
 
 describe('sanitizeRef', () => {

--- a/packages/core/src/dependabot/branch-name.ts
+++ b/packages/core/src/dependabot/branch-name.ts
@@ -11,6 +11,8 @@ export function getBranchNameForUpdate({
   packageEcosystem,
   targetBranchName,
   directory,
+  directories,
+  changedFiles,
   dependencyGroupName,
   dependencies,
   separator = '/',
@@ -18,6 +20,8 @@ export function getBranchNameForUpdate({
   packageEcosystem: PackageEcosystem;
   targetBranchName?: string;
   directory?: string;
+  directories?: string[];
+  changedFiles?: { path: string }[];
   dependencyGroupName?: string | null;
   dependencies: DependabotExistingPrDependency[];
   separator?: string;
@@ -25,6 +29,16 @@ export function getBranchNameForUpdate({
   // Based on dependabot-core implementation:
   // https://github.com/dependabot/dependabot-core/blob/main/common/lib/dependabot/pull_request_creator/branch_namer/solo_strategy.rb
   // https://github.com/dependabot/dependabot-core/blob/main/common/lib/dependabot/pull_request_creator/branch_namer/dependency_group_strategy.rb
+  //
+  // For grouped updates across multiple directories we intentionally omit the directory segment.
+  // Those PRs span multiple manifests, so deriving the branch name from the first changed file
+  // would make the branch unstable and arbitrarily tied to one directory.
+  const resolvedDirectory =
+    directory ||
+    (dependencyGroupName && directories && directories.length > 1
+      ? undefined
+      : directories?.find((dir) => changedFiles?.[0]?.path?.startsWith(dir)));
+
   let branchName: string;
   const branchNameMightBeTooLong = dependencyGroupName || dependencies.length > 1;
   if (branchNameMightBeTooLong) {
@@ -54,8 +68,8 @@ export function getBranchNameForUpdate({
       packageEcosystem,
       targetBranchName,
       // normalize directory to remove leading/trailing slashes and replace remaining ones with the separator
-      directory
-        ? directory
+      resolvedDirectory
+        ? resolvedDirectory
             .split('/')
             .filter((part) => part.length > 0)
             .join(separator)

--- a/packages/core/src/dependabot/config.ts
+++ b/packages/core/src/dependabot/config.ts
@@ -60,6 +60,7 @@ export const DependabotGroupSchema = z.object({
     .optional(),
   'applies-to': z.enum(['version-updates', 'security-updates']).optional(),
   'dependency-type': z.enum(['development', 'production']).optional(),
+  'group-by': z.enum(['dependency-name']).optional(),
   'patterns': z.string().array().optional(),
   'exclude-patterns': z.string().array().optional(),
   'update-types': z.enum(['major', 'minor', 'patch']).array().optional(),

--- a/packages/core/src/dependabot/job-builder.test.ts
+++ b/packages/core/src/dependabot/job-builder.test.ts
@@ -194,6 +194,7 @@ describe('mapGroupsFromDependabotConfigToJobConfig', () => {
     const dependencyGroups: Record<string, DependabotGroup> = {
       group: {
         'applies-to': 'version-updates',
+        'group-by': 'dependency-name',
         'patterns': ['pattern1', 'pattern2'],
         'exclude-patterns': ['exclude1'],
         'dependency-type': 'production',
@@ -207,6 +208,7 @@ describe('mapGroupsFromDependabotConfigToJobConfig', () => {
       {
         'name': 'group',
         'applies-to': 'version-updates',
+        'group-by': 'dependency-name',
         'rules': {
           'patterns': ['pattern1', 'pattern2'],
           'exclude-patterns': ['exclude1'],

--- a/packages/core/src/dependabot/job-builder.ts
+++ b/packages/core/src/dependabot/job-builder.ts
@@ -306,6 +306,7 @@ export function mapGroupsFromDependabotConfigToJobConfig(
       return {
         'name': name,
         'applies-to': group['applies-to'],
+        'group-by': group['group-by'],
         'rules': {
           'patterns': group.patterns?.length ? group.patterns : ['*'],
           'exclude-patterns': group['exclude-patterns'],

--- a/packages/core/src/dependabot/job.ts
+++ b/packages/core/src/dependabot/job.ts
@@ -72,6 +72,7 @@ export type DependabotGroupRuleJob = z.infer<typeof DependabotGroupRuleJobSchema
 export const DependabotGroupJobSchema = z.object({
   'name': z.string(),
   'applies-to': z.string().nullish(),
+  'group-by': z.enum(['dependency-name']).nullish(),
   'rules': DependabotGroupRuleJobSchema,
 });
 export type DependabotGroupJob = z.infer<typeof DependabotGroupJobSchema>;

--- a/packages/runner/src/local/azure/server.ts
+++ b/packages/runner/src/local/azure/server.ts
@@ -106,7 +106,9 @@ export class AzureLocalDependabotServer extends LocalDependabotServer {
         const sourceBranch = getBranchNameForUpdate({
           packageEcosystem: update['package-ecosystem'],
           targetBranchName: targetBranch,
-          directory: update.directory || update.directories?.find((dir) => changedFiles[0]?.path?.startsWith(dir)),
+          directory: update.directory,
+          directories: update.directories,
+          changedFiles,
           dependencyGroupName: persisted['dependency-group-name'],
           dependencies: persisted.dependencies,
           separator: update['pull-request-branch-name']?.separator,


### PR DESCRIPTION
Add support for `groups.<name>.group-by: dependency-name` and use shared branch naming logic for grouped multi-directory updates.