### PR TITLE
Add first-stage multi-ecosystem update support.

### DIFF
--- a/.changeset/fresh-bulldogs-smile.md
+++ b/.changeset/fresh-bulldogs-smile.md
@@ -1,0 +1,6 @@
+---
+"@paklo/core": minor
+---
+
+Add first-stage multi-ecosystem update support.
+This includes validating group usage in config, merging effective group/update settings for branching and PR metadata, and propagating `multi-ecosystem-update` through jobs and usage telemetry.

--- a/packages/core/src/azure/runner/runner.ts
+++ b/packages/core/src/azure/runner/runner.ts
@@ -67,14 +67,6 @@ export class AzureLocalJobsRunner extends LocalJobsRunner {
       approverClient,
     } = this;
 
-    // Print a warning about multi-ecosystem updates not being fully supported
-    // TODO: Implement full support for multi-ecosystem updates (not sure this will be possible on the local model)
-    if (config['multi-ecosystem-groups'] || config.updates?.some((u) => u['multi-ecosystem-group'])) {
-      logger.warn(
-        'Multi-ecosystem updates are not working yet. Only parsing and validation is supported at this time.',
-      );
-    }
-
     // Print a warning about the required workarounds for security-only updates, if any update is configured as such
     // TODO: If and when Dependabot supports a better way to do security-only updates, remove this.
     if (config.updates?.some((u) => u['open-pull-requests-limit'] === 0)) {
@@ -228,6 +220,7 @@ export class AzureLocalJobsRunner extends LocalJobsRunner {
         'owner': url.value.toString(),
         'project': `${url.value.toString().replace(/\/$/, '')}/${url.project}`,
         'package-manager': job['package-manager'],
+        'multi-ecosystem-update': job['multi-ecosystem-update'] || false,
       };
     }
 
@@ -244,12 +237,12 @@ export class AzureLocalJobsRunner extends LocalJobsRunner {
       const existingPullRequestsForPackageManager = parsePullRequestProperties(existingPullRequests, packageManager);
 
       const builder = new DependabotJobBuilder({
+        experiments,
         source: { provider: 'azure', ...url },
         config,
         update,
         systemAccessToken: gitToken,
         githubToken,
-        experiments,
         debug: false,
       });
 

--- a/packages/core/src/azure/runner/server.test.ts
+++ b/packages/core/src/azure/runner/server.test.ts
@@ -8,7 +8,7 @@ import {
   PR_PROPERTY_DEPENDABOT_DEPENDENCIES,
   PR_PROPERTY_DEPENDABOT_PACKAGE_MANAGER,
 } from '@/azure/client';
-import type { DependabotJobBuilderOutput, DependabotUpdate } from '@/dependabot';
+import type { DependabotConfig, DependabotJobBuilderOutput, DependabotUpdate } from '@/dependabot';
 
 import { extractRepositoryUrl } from '../url-parts';
 import { AzureLocalDependabotServer, type AzureLocalDependabotServerOptions } from './server';
@@ -50,6 +50,10 @@ describe('AzureLocalDependabotServer', () => {
       authorClient,
       autoApprove: false,
       approverClient,
+      config: {
+        version: 2,
+        updates: [],
+      } as unknown as DependabotConfig,
       setAutoComplete: false,
       autoCompleteIgnoreConfigIds: [],
       existingBranchNames,
@@ -249,6 +253,70 @@ describe('AzureLocalDependabotServer', () => {
       expect(result).toEqual(true);
       expect(authorClient.createPullRequest).toHaveBeenCalled();
       expect(approverClient!.approvePullRequest).toHaveBeenCalled();
+    });
+
+    it('should use merged multi-ecosystem group settings when creating a pull request', async () => {
+      options.config = {
+        'version': 2,
+        'multi-ecosystem-groups': {
+          infrastructure: {
+            'schedule': { interval: 'weekly' },
+            'assignees': ['@platform-team'],
+            'labels': ['infrastructure'],
+            'milestone': '42',
+            'target-branch': 'release/1.x',
+            'pull-request-branch-name': { separator: '-' },
+          },
+        },
+        'updates': [],
+      } as unknown as DependabotConfig;
+      update = {
+        'package-ecosystem': 'docker',
+        'directory': '/',
+        'patterns': ['*'],
+        'multi-ecosystem-group': 'infrastructure',
+        'assignees': ['@docker-admin'],
+        'labels': ['docker'],
+      };
+
+      server = new AzureLocalDependabotServer(options);
+      server.add({
+        id: '1',
+        update,
+        job: jobBuilderOutput.job,
+        jobToken: 'test-token',
+        credentialsToken: 'test-creds-token',
+        credentials: jobBuilderOutput.credentials,
+      });
+
+      vi.mocked(authorClient.createPullRequest).mockResolvedValue(11);
+
+      const result = await (server as any).handle('1', {
+        type: 'create_pull_request',
+        data: {
+          'base-commit-sha': '1234abcd',
+          'commit-message': 'Test commit message',
+          'pr-body': 'Test body',
+          'pr-title': 'Test PR',
+          'updated-dependency-files': [],
+          'dependencies': [{ name: 'nginx', version: '1.0.0', requirements: [], directory: '/' }],
+          'dependency-group': { name: 'infrastructure' },
+        },
+      });
+
+      expect(result).toEqual(true);
+      expect(authorClient.getDefaultBranch).not.toHaveBeenCalled();
+      expect(authorClient.createPullRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          target: { branch: 'release/1.x' },
+          assignees: ['@platform-team', '@docker-admin'],
+          labels: ['infrastructure', 'docker'],
+          workItems: ['42'],
+          source: expect.objectContaining({
+            branch: expect.stringContaining('dependabot-docker-release'),
+          }),
+        }),
+      );
     });
 
     it('should skip processing "update_pull_request" if "dryRun" is true', async () => {

--- a/packages/core/src/azure/runner/server.ts
+++ b/packages/core/src/azure/runner/server.ts
@@ -9,8 +9,10 @@ import {
   parsePullRequestProperties,
 } from '@/azure/client';
 import {
+  type DependabotConfig,
   type DependabotRequest,
   getBranchNameForUpdate,
+  getEffectiveUpdateSettings,
   getPersistedPr,
   getPullRequestCloseReason,
   getPullRequestDescription,
@@ -22,6 +24,7 @@ import { logger } from '@/logger';
 import { type AzureDevOpsRepositoryUrl } from '../url-parts';
 
 export type AzureLocalDependabotServerOptions = LocalDependabotServerOptions & {
+  config: DependabotConfig;
   url: AzureDevOpsRepositoryUrl;
   authorClient: AzureDevOpsClientWrapper;
   autoApprove: boolean;
@@ -57,6 +60,7 @@ export class AzureLocalDependabotServer extends LocalDependabotServer {
       autoCompleteIgnoreConfigIds,
       author,
       dryRun,
+      config,
     } = options;
 
     const { type, data } = request;
@@ -71,6 +75,7 @@ export class AzureLocalDependabotServer extends LocalDependabotServer {
     const { 'package-manager': packageManager } = job;
 
     const update = this.update(id)!; // exists because job exists
+    const effective = getEffectiveUpdateSettings(config, update);
     const { project, repository } = url;
 
     switch (type) {
@@ -104,7 +109,8 @@ export class AzureLocalDependabotServer extends LocalDependabotServer {
 
         const persisted = getPersistedPr(data);
         const changedFiles = getPullRequestChangedFiles(data);
-        const targetBranch = update['target-branch'] || (await authorClient.getDefaultBranch({ project, repository }));
+        const targetBranch =
+          effective['target-branch'] || (await authorClient.getDefaultBranch({ project, repository }));
         const sourceBranch = getBranchNameForUpdate({
           packageEcosystem: update['package-ecosystem'],
           targetBranchName: targetBranch,
@@ -113,7 +119,7 @@ export class AzureLocalDependabotServer extends LocalDependabotServer {
           changedFiles,
           dependencyGroupName: persisted['dependency-group-name'],
           dependencies: persisted.dependencies,
-          separator: update['pull-request-branch-name']?.separator,
+          separator: effective['pull-request-branch-name']?.separator,
         });
 
         // Check if the source branch already exists or conflicts with an existing branch
@@ -158,9 +164,9 @@ export class AzureLocalDependabotServer extends LocalDependabotServer {
                 mergeStrategy: mergeStrategy ?? 'squash',
               }
             : undefined,
-          assignees: update.assignees,
-          labels: update.labels?.map((label) => label?.trim()) || [],
-          workItems: update.milestone ? [update.milestone] : [],
+          assignees: effective.assignees,
+          labels: effective.labels?.map((label) => label?.trim()) || [],
+          workItems: effective.milestone ? [effective.milestone] : [],
           changes: changedFiles,
           properties: buildPullRequestProperties(packageManager, persisted),
         });

--- a/packages/core/src/dependabot/config.test.ts
+++ b/packages/core/src/dependabot/config.test.ts
@@ -2,7 +2,6 @@ import { readFile } from 'node:fs/promises';
 
 import * as yaml from 'js-yaml';
 import { describe, expect, it } from 'vitest';
-import { ZodError } from 'zod';
 
 import {
   BETA_ECOSYSTEMS,
@@ -123,157 +122,30 @@ describe('DependabotScheduleSchema', () => {
 });
 
 describe('Directory validation', () => {
-  it('Should reject directory with glob patterns', async () => {
-    const invalidConfigs = [
-      {
-        version: 2,
-        updates: [
-          { 'package-ecosystem': 'npm', 'schedule': { interval: 'cron', cronjob: '0 0 * * *' }, 'directory': '/src/*' },
-        ],
-      },
-      {
-        version: 2,
-        updates: [
-          {
-            'package-ecosystem': 'npm',
-            'schedule': { interval: 'cron', cronjob: '0 0 * * *' },
-            'directory': '/src/app-?',
-          },
-        ],
-      },
-      {
-        version: 2,
-        updates: [
-          {
-            'package-ecosystem': 'npm',
-            'schedule': { interval: 'cron', cronjob: '0 0 * * *' },
-            'directory': '/src/[abc]',
-          },
-        ],
-      },
-      {
-        version: 2,
-        updates: [
-          {
-            'package-ecosystem': 'npm',
-            'schedule': { interval: 'cron', cronjob: '0 0 * * *' },
-            'directory': '/src/{a,b}',
-          },
-        ],
-      },
-    ];
+  it('Should reject glob patterns in directory', async () => {
+    const testCases = ['/src/*', '/src/app-?', '/src/[abc]', '/src/{a,b}'];
 
-    for (const config of invalidConfigs) {
-      await expect(DependabotConfigSchema.parseAsync(config)).rejects.toThrow(
-        "The 'directory' field must not include glob pattern.",
-      );
+    for (const directory of testCases) {
+      await expect(
+        DependabotUpdateSchema.parseAsync({
+          'package-ecosystem': 'npm',
+          'schedule': { interval: 'daily' },
+          directory,
+        }),
+      ).rejects.toThrow("The 'directory' field must not include glob pattern.");
     }
   });
 
-  it('Should accept directory without glob patterns', async () => {
-    const validConfig = {
-      version: 2,
-      updates: [
-        {
-          'package-ecosystem': 'npm',
-          'schedule': { interval: 'cron', cronjob: '0 0 * * *' },
-          'directory': '/src/app',
-        },
-      ],
-    };
+  it('Should accept valid directory paths', async () => {
+    const validPaths = ['/src/app', '/src/app-name', '/src/app_name', '/src/app.name', '/src/app@version'];
 
-    const result = await DependabotConfigSchema.parseAsync(validConfig);
-    expect(result.updates[0]?.directory).toBe('/src/app');
-  });
-
-  it('Should accept valid directory paths with special but non-glob characters', async () => {
-    const validConfig = {
-      version: 2,
-      updates: [
-        {
-          'package-ecosystem': 'npm',
-          'schedule': { interval: 'cron', cronjob: '0 0 * * *' },
-          'directory': '/src/app-name',
-        },
-        {
-          'package-ecosystem': 'docker',
-          'schedule': { interval: 'cron', cronjob: '0 0 * * *' },
-          'directory': '/src/app_name',
-        },
-        {
-          'package-ecosystem': 'nuget',
-          'schedule': { interval: 'cron', cronjob: '0 0 * * *' },
-          'directory': '/src/app.name',
-        },
-        {
-          'package-ecosystem': 'pip',
-          'schedule': { interval: 'cron', cronjob: '0 0 * * *' },
-          'directory': '/src/app@version',
-        },
-      ],
-    };
-
-    const result = await DependabotConfigSchema.parseAsync(validConfig);
-    expect(result.updates).toHaveLength(4);
-    expect(result.updates[0]?.directory).toBe('/src/app-name');
-    expect(result.updates[1]?.directory).toBe('/src/app_name');
-    expect(result.updates[2]?.directory).toBe('/src/app.name');
-    expect(result.updates[3]?.directory).toBe('/src/app@version');
-  });
-
-  it('Should validate individual DependabotUpdate schema with glob patterns', async () => {
-    const invalidUpdate = {
-      'package-ecosystem': 'npm',
-      'schedule': { interval: 'cron', cronjob: '0 0 * * *' },
-      'directory': '/src/*',
-    };
-
-    await expect(DependabotUpdateSchema.parseAsync(invalidUpdate)).rejects.toThrow(
-      "The 'directory' field must not include glob pattern.",
-    );
-  });
-
-  it('Should validate individual DependabotUpdate schema without glob patterns', async () => {
-    const validUpdate = {
-      'package-ecosystem': 'npm',
-      'schedule': { interval: 'cron', cronjob: '0 0 * * *' },
-      'directory': '/src/app',
-    };
-
-    const result = await DependabotUpdateSchema.parseAsync(validUpdate);
-    expect(result.directory).toBe('/src/app');
-  });
-
-  it('Should reject config file with glob patterns in directory', async () => {
-    const configWithGlob = {
-      version: 2,
-      updates: [
-        {
-          'package-ecosystem': 'npm',
-          'schedule': { interval: 'cron', cronjob: '0 0 * * *' },
-          'directory': '/src/*',
-        },
-        {
-          'package-ecosystem': 'docker',
-          'schedule': { interval: 'cron', cronjob: '0 0 * * *' },
-          'directory': '/apps/[abc]',
-        },
-      ],
-    };
-
-    try {
-      await DependabotConfigSchema.parseAsync(configWithGlob);
-      expect.fail('Expected validation to fail but it passed');
-    } catch (error) {
-      expect(error).toBeInstanceOf(ZodError);
-      const zodError = error as ZodError;
-      expect(zodError.issues).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            message: "The 'directory' field must not include glob pattern.",
-          }),
-        ]),
-      );
+    for (const directory of validPaths) {
+      const result = await DependabotUpdateSchema.parseAsync({
+        'package-ecosystem': 'npm',
+        'schedule': { interval: 'daily' },
+        directory,
+      });
+      expect(result.directory).toBe(directory);
     }
   });
 });
@@ -742,5 +614,101 @@ describe('Validate registries', () => {
     expect(() => validateConfiguration(updates, registries)).toThrow(
       `Referenced registries: 'dummy3' have not been configured in the root of dependabot.yml`,
     );
+  });
+
+  it('Schedule is required when not using multi-ecosystem-group', async () => {
+    const configWithoutSchedule = {
+      version: 2,
+      updates: [{ 'package-ecosystem': 'npm', 'directory': '/' }],
+    };
+
+    await expect(DependabotConfigSchema.parseAsync(configWithoutSchedule)).rejects.toThrow(
+      "The 'schedule' field is required when 'multi-ecosystem-group' is not specified.",
+    );
+  });
+
+  it('Patterns is required when using multi-ecosystem-group', async () => {
+    const configWithoutPatterns = {
+      'version': 2,
+      'multi-ecosystem-groups': {
+        'my-group': { schedule: { interval: 'weekly' } },
+      },
+      'updates': [{ 'package-ecosystem': 'npm', 'directory': '/', 'multi-ecosystem-group': 'my-group' }],
+    };
+
+    await expect(DependabotConfigSchema.parseAsync(configWithoutPatterns)).rejects.toThrow(
+      "The 'patterns' field is required and must contain at least one pattern when 'multi-ecosystem-group' is specified.",
+    );
+  });
+
+  it('Schedule is optional when using multi-ecosystem-group', async () => {
+    const validConfig = {
+      'version': 2,
+      'multi-ecosystem-groups': {
+        'my-group': { schedule: { interval: 'weekly' } },
+      },
+      'updates': [
+        { 'package-ecosystem': 'npm', 'directory': '/', 'multi-ecosystem-group': 'my-group', 'patterns': ['*'] },
+      ],
+    };
+
+    const result = await DependabotConfigSchema.parseAsync(validConfig);
+    expect(result.updates[0]?.schedule).toBeUndefined();
+    expect(result.updates[0]?.['multi-ecosystem-group']).toBe('my-group');
+  });
+});
+
+describe('Multi-ecosystem groups validation', () => {
+  it('Should reject when referencing undefined group', async () => {
+    const config = {
+      'version': 2,
+      'multi-ecosystem-groups': {
+        'my-group': { schedule: { interval: 'weekly' } },
+      },
+      'updates': [
+        { 'package-ecosystem': 'npm', 'directory': '/', 'multi-ecosystem-group': 'undefined-group', 'patterns': ['*'] },
+      ],
+    };
+
+    await expect(DependabotConfigSchema.parseAsync(config)).rejects.toThrow(
+      "Referenced multi-ecosystem groups: 'undefined-group' have not been defined in 'multi-ecosystem-groups'.",
+    );
+  });
+
+  it('Should reject when group is defined but not used', async () => {
+    const config = {
+      'version': 2,
+      'multi-ecosystem-groups': {
+        'unused-group': { schedule: { interval: 'weekly' } },
+      },
+      'updates': [{ 'package-ecosystem': 'npm', 'directory': '/', 'schedule': { interval: 'daily' } }],
+    };
+
+    await expect(DependabotConfigSchema.parseAsync(config)).rejects.toThrow(
+      "Multi-ecosystem groups: 'unused-group' have been defined but are not referenced by any update.",
+    );
+  });
+
+  it('Should allow valid multi-ecosystem group configuration', async () => {
+    const config = {
+      'version': 2,
+      'multi-ecosystem-groups': {
+        'my-group': { schedule: { interval: 'weekly' } },
+      },
+      'updates': [
+        { 'package-ecosystem': 'npm', 'directory': '/client', 'multi-ecosystem-group': 'my-group', 'patterns': ['*'] },
+        {
+          'package-ecosystem': 'docker',
+          'directory': '/server',
+          'multi-ecosystem-group': 'my-group',
+          'patterns': ['*'],
+        },
+      ],
+    };
+
+    const result = await DependabotConfigSchema.parseAsync(config);
+    expect(result.updates).toHaveLength(2);
+    expect(result.updates[0]?.['multi-ecosystem-group']).toBe('my-group');
+    expect(result.updates[1]?.['multi-ecosystem-group']).toBe('my-group');
   });
 });

--- a/packages/core/src/dependabot/config.ts
+++ b/packages/core/src/dependabot/config.ts
@@ -219,7 +219,7 @@ export const DependabotUpdateSchema = z
     'pull-request-branch-name': DependabotPullRequestBranchNameSchema.optional(),
     'rebase-strategy': z.string().optional(),
     'registries': z.string().array().optional(),
-    'schedule': DependabotScheduleSchema,
+    'schedule': DependabotScheduleSchema.optional(),
     'target-branch': z.string().optional(),
     'vendor': z.boolean().optional(),
     'versioning-strategy': VersioningStrategySchema.optional(),
@@ -239,13 +239,22 @@ export const DependabotUpdateSchema = z
 
     value['open-pull-requests-limit'] ??= 5; // default to 5 if not specified
 
-    // The patterns key is required when using multi-ecosystem-group.
-    // You can specify dependency patterns to include only certain dependencies in the group,
-    // or use ["*"] to include all dependencies.
-    if (value['multi-ecosystem-group'] && (!value.patterns || value.patterns.length === 0)) {
-      addIssue(
-        "The 'patterns' field must be specified and contain at least one pattern when using 'multi-ecosystem-group'.",
-      );
+    // When using multi-ecosystem-group, schedule is not required (comes from the group)
+    // When NOT using multi-ecosystem-group, schedule is required
+    if (value['multi-ecosystem-group']) {
+      // The patterns key is required when using multi-ecosystem-group.
+      // You can specify dependency patterns to include only certain dependencies in the group,
+      // or use ["*"] to include all dependencies.
+      if (!value.patterns || value.patterns.length === 0) {
+        addIssue(
+          "The 'patterns' field is required and must contain at least one pattern when 'multi-ecosystem-group' is specified.",
+        );
+      }
+    } else {
+      // When not using multi-ecosystem-group, schedule is required
+      if (!value.schedule) {
+        addIssue("The 'schedule' field is required when 'multi-ecosystem-group' is not specified.");
+      }
     }
 
     return value;
@@ -343,10 +352,53 @@ export const DependabotConfigSchema = z
       }
     }
 
+    // validate multi-ecosystem-groups: ensure all defined groups are used and all referenced groups exist
+    if (value['multi-ecosystem-groups']) {
+      const definedGroups = Object.keys(value['multi-ecosystem-groups']);
+      const referencedGroups: string[] = [];
+
+      for (const update of value.updates) {
+        if (update['multi-ecosystem-group']) {
+          referencedGroups.push(update['multi-ecosystem-group']);
+        }
+      }
+
+      // ensure there are no referenced groups that have not been defined
+      const missingDefinitions = referencedGroups.filter((group) => !definedGroups.includes(group));
+      if (missingDefinitions.length > 0) {
+        addIssue(
+          `Referenced multi-ecosystem groups: '${missingDefinitions.join(',')}' have not been defined in 'multi-ecosystem-groups'.`,
+        );
+      }
+
+      // ensure there are no defined groups that have not been referenced
+      const unusedGroups = definedGroups.filter((group) => !referencedGroups.includes(group));
+      if (unusedGroups.length > 0) {
+        addIssue(
+          `Multi-ecosystem groups: '${unusedGroups.join(',')}' have been defined but are not referenced by any update.`,
+        );
+      }
+    }
+
     return value;
   });
 
 export type DependabotConfig = z.infer<typeof DependabotConfigSchema>;
+
+export function getEffectiveUpdateSettings(config: DependabotConfig, update: DependabotUpdate) {
+  const groupName = update['multi-ecosystem-group'];
+  const group = groupName ? config['multi-ecosystem-groups']?.[groupName] : undefined;
+
+  return {
+    'schedule': group?.schedule ?? update.schedule,
+    'assignees': Array.from(new Set([...(group?.assignees ?? []), ...(update.assignees ?? [])])),
+    'labels': Array.from(new Set([...(group?.labels ?? []), ...(update.labels ?? [])])),
+    'milestone': group?.milestone ?? update.milestone,
+    'target-branch': group?.['target-branch'] ?? update['target-branch'],
+    'commit-message': group?.['commit-message'] ?? update['commit-message'],
+    'pull-request-branch-name': group?.['pull-request-branch-name'] ?? update['pull-request-branch-name'],
+  };
+}
 
 export function parseUpdates(config: DependabotConfig, configPath: string): DependabotUpdate[] {
   const updates: DependabotUpdate[] = [];

--- a/packages/core/src/dependabot/job-builder.test.ts
+++ b/packages/core/src/dependabot/job-builder.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect, it } from 'vitest';
 
-import type { DependabotGroup, DependabotIgnoreCondition, DependabotUpdate } from './config';
 import {
+  type DependabotConfig,
+  type DependabotGroup,
+  type DependabotIgnoreCondition,
+  type DependabotUpdate,
+  getEffectiveUpdateSettings,
+} from './config';
+import {
+  DependabotJobBuilder,
   type DependabotSourceInfo,
   mapAllowedUpdatesFromDependabotConfigToJobConfig,
   mapExperiments,
@@ -65,6 +72,11 @@ describe('mapExperiments', () => {
 });
 
 describe('mapSourceFromDependabotConfigToJobConfig', () => {
+  const config = {
+    version: 2,
+    updates: [],
+  } as unknown as DependabotConfig;
+
   it('should map source correctly for Azure DevOps Services', () => {
     const sourceInfo: DependabotSourceInfo = {
       'provider': 'azure',
@@ -79,7 +91,7 @@ describe('mapSourceFromDependabotConfigToJobConfig', () => {
       'directories': [],
     } as DependabotUpdate;
 
-    const result = mapSourceFromDependabotConfigToJobConfig(sourceInfo, update);
+    const result = mapSourceFromDependabotConfigToJobConfig(sourceInfo, config, update);
     expect(result).toMatchObject({
       'provider': 'azure',
       'api-endpoint': 'https://dev.azure.com',
@@ -102,13 +114,78 @@ describe('mapSourceFromDependabotConfigToJobConfig', () => {
       'directories': [],
     } as DependabotUpdate;
 
-    const result = mapSourceFromDependabotConfigToJobConfig(sourceInfo, update);
+    const result = mapSourceFromDependabotConfigToJobConfig(sourceInfo, config, update);
     expect(result).toMatchObject({
       'provider': 'azure',
       'api-endpoint': 'https://my-org.com:8443/tfs',
       'hostname': 'my-org.com',
       'repo': 'tfs/my-collection/my-project/_git/my-repo',
     });
+  });
+
+  it('should prefer group target branch for multi-ecosystem updates', () => {
+    const sourceInfo: DependabotSourceInfo = {
+      'provider': 'azure',
+      'api-endpoint': 'https://dev.azure.com',
+      'hostname': 'dev.azure.com',
+      'repository-slug': 'my-org/my-project/_git/my-repo',
+    };
+    const groupedConfig = {
+      'version': 2,
+      'multi-ecosystem-groups': {
+        infrastructure: {
+          'schedule': { interval: 'weekly' },
+          'target-branch': 'release/1.x',
+        },
+      },
+      'updates': [],
+    } as unknown as DependabotConfig;
+    const update = {
+      'package-ecosystem': 'docker',
+      'directory': '/',
+      'patterns': ['*'],
+      'multi-ecosystem-group': 'infrastructure',
+    } as DependabotUpdate;
+
+    const result = mapSourceFromDependabotConfigToJobConfig(sourceInfo, groupedConfig, update);
+    expect(result.branch).toBe('release/1.x');
+  });
+});
+
+describe('getEffectiveUpdateSettings', () => {
+  it('should merge additive and group-only multi-ecosystem settings', () => {
+    const config = {
+      'version': 2,
+      'multi-ecosystem-groups': {
+        infrastructure: {
+          'schedule': { interval: 'weekly' },
+          'assignees': ['@platform-team'],
+          'labels': ['infrastructure'],
+          'milestone': '12',
+          'target-branch': 'release/1.x',
+          'commit-message': { prefix: 'chore' },
+          'pull-request-branch-name': { separator: '-' },
+        },
+      },
+      'updates': [],
+    } as unknown as DependabotConfig;
+    const update = {
+      'package-ecosystem': 'docker',
+      'directory': '/',
+      'patterns': ['*'],
+      'multi-ecosystem-group': 'infrastructure',
+      'assignees': ['@docker-admin'],
+      'labels': ['docker'],
+    } as DependabotUpdate;
+
+    const result = getEffectiveUpdateSettings(config, update);
+
+    expect(result.assignees).toEqual(['@platform-team', '@docker-admin']);
+    expect(result.labels).toEqual(['infrastructure', 'docker']);
+    expect(result.milestone).toBe('12');
+    expect(result['target-branch']).toBe('release/1.x');
+    expect(result['commit-message']).toEqual({ prefix: 'chore' });
+    expect(result['pull-request-branch-name']).toEqual({ separator: '-' });
   });
 });
 
@@ -243,5 +320,53 @@ describe('mapGroupsFromDependabotConfigToJobConfig', () => {
     const result = mapGroupsFromDependabotConfigToJobConfig(dependencyGroups);
 
     expect(result).toEqual([{ name: 'group', rules: { patterns: ['*'] } }]);
+  });
+});
+
+describe('DependabotJobBuilder', () => {
+  it('should use group commit message options for multi-ecosystem jobs', () => {
+    const builder = new DependabotJobBuilder({
+      experiments: {},
+      source: {
+        'provider': 'azure',
+        'hostname': 'dev.azure.com',
+        'api-endpoint': 'https://dev.azure.com',
+        'repository-slug': 'my-org/my-project/_git/my-repo',
+      },
+      config: {
+        'version': 2,
+        'multi-ecosystem-groups': {
+          infrastructure: {
+            'schedule': { interval: 'weekly' },
+            'commit-message': {
+              'prefix': 'chore',
+              'prefix-development': 'deps-dev',
+              'include': 'scope',
+            },
+          },
+        },
+        'updates': [],
+      } as unknown as DependabotConfig,
+      update: {
+        'package-ecosystem': 'docker',
+        'directory': '/',
+        'patterns': ['*'],
+        'multi-ecosystem-group': 'infrastructure',
+        'schedule': { interval: 'daily' },
+      } as DependabotUpdate,
+      debug: false,
+    });
+
+    const result = builder.forUpdate({
+      id: '1',
+      command: 'update',
+      existingPullRequests: [],
+    });
+
+    expect(result.job['commit-message-options']).toEqual({
+      'prefix': 'chore',
+      'prefix-development': 'deps-dev',
+      'include-scope': true,
+    });
   });
 });

--- a/packages/core/src/dependabot/job-builder.ts
+++ b/packages/core/src/dependabot/job-builder.ts
@@ -1,14 +1,15 @@
 import type { SecurityVulnerability } from '@/github';
 
-import type {
-  DependabotAllowCondition,
-  DependabotConfig,
-  DependabotGroup,
-  DependabotIgnoreCondition,
-  DependabotRegistry,
-  DependabotUpdate,
-  PackageEcosystem,
-  VersioningStrategy,
+import {
+  type DependabotAllowCondition,
+  type DependabotConfig,
+  type DependabotGroup,
+  type DependabotIgnoreCondition,
+  type DependabotRegistry,
+  type DependabotUpdate,
+  type PackageEcosystem,
+  type VersioningStrategy,
+  getEffectiveUpdateSettings,
 } from './config';
 import { setExperiment } from './experiments';
 import type {
@@ -53,19 +54,19 @@ export class DependabotJobBuilder {
   private readonly credentials: DependabotCredential[];
 
   constructor({
+    experiments,
     source,
     config,
     update,
     systemAccessUser,
     systemAccessToken,
     githubToken,
-    experiments,
     debug,
   }: {
+    experiments: DependabotExperiments;
     source: DependabotSourceInfo;
     config: DependabotConfig;
     update: DependabotUpdate;
-    experiments: DependabotExperiments;
     systemAccessUser?: string;
     systemAccessToken?: string;
     githubToken?: string;
@@ -79,7 +80,7 @@ export class DependabotJobBuilder {
     this.experiments = setExperiment(experiments, 'enable_beta_ecosystems', config['enable-beta-ecosystems']);
 
     this.packageManager = mapPackageEcosystemToPackageManager(update['package-ecosystem']);
-    this.source = mapSourceFromDependabotConfigToJobConfig(source, update);
+    this.source = mapSourceFromDependabotConfigToJobConfig(source, config, update);
     this.credentials = mapCredentials({
       sourceHostname: source.hostname,
       systemAccessUser,
@@ -172,6 +173,10 @@ export class DependabotJobBuilder {
       source.directory = undefined;
     }
 
+    const effective = getEffectiveUpdateSettings(this.config, this.update);
+    const multiEcosystemGroupName = this.update['multi-ecosystem-group'];
+    const multiEcosystemUpdate = !!multiEcosystemGroupName;
+
     return {
       job: {
         'id': id,
@@ -190,10 +195,9 @@ export class DependabotJobBuilder {
         'existing-pull-requests': existingPullRequests.filter((pr) => !('dependency-group-name' in pr)),
         'existing-group-pull-requests': existingPullRequests.filter((pr) => 'dependency-group-name' in pr),
         'commit-message-options': {
-          'prefix': this.update['commit-message']?.prefix ?? null,
-          'prefix-development': this.update['commit-message']?.['prefix-development'] ?? null,
-          'include-scope':
-            this.update['commit-message']?.include?.toLocaleLowerCase()?.trim() === 'scope' ? true : null,
+          'prefix': effective['commit-message']?.prefix ?? null,
+          'prefix-development': effective['commit-message']?.['prefix-development'] ?? null,
+          'include-scope': effective['commit-message']?.include?.toLocaleLowerCase()?.trim() === 'scope' ? true : null,
         },
         'cooldown': this.update.cooldown,
         'experiments': mapExperiments(this.experiments),
@@ -209,12 +213,7 @@ export class DependabotJobBuilder {
         'proxy-log-response-body-on-auth-failure': true,
         'max-updater-run-time': 2700,
         'enable-beta-ecosystems': this.config['enable-beta-ecosystems'] || false,
-        // Updates across ecosystems is still in development
-        // See https://github.com/dependabot/dependabot-core/issues/8126
-        //     https://github.com/dependabot/dependabot-core/pull/12339
-        // It needs to merged in the core repo first before we support it
-        // However, to match current job configs and to prevent surprises, we disable it
-        'multi-ecosystem-update': false,
+        'multi-ecosystem-update': multiEcosystemUpdate,
         'exclude-paths': this.update['exclude-paths'],
       },
       credentials: this.credentials,
@@ -263,14 +262,16 @@ export function mapPackageEcosystemToPackageManager(ecosystem: PackageEcosystem)
 
 export function mapSourceFromDependabotConfigToJobConfig(
   source: DependabotSourceInfo,
+  config: DependabotConfig,
   update: DependabotUpdate,
 ): DependabotSource {
+  const effective = getEffectiveUpdateSettings(config, update);
   return {
     'provider': source.provider,
     'api-endpoint': source['api-endpoint'],
     'hostname': source.hostname,
     'repo': source['repository-slug'],
-    'branch': update['target-branch'],
+    'branch': effective['target-branch'],
     'commit': null, // use latest commit of target branch
     'directory': update.directory,
     'directories': update.directories,

--- a/packages/core/src/runner/run.ts
+++ b/packages/core/src/runner/run.ts
@@ -29,7 +29,10 @@ export type RunJobOptions = {
   updaterImage?: string;
   secretMasker: SecretMasker;
   debug: boolean;
-  usage: Pick<UsageTelemetryRequestData, 'trigger' | 'provider' | 'owner' | 'project' | 'package-manager'>;
+  usage: Pick<
+    UsageTelemetryRequestData,
+    'trigger' | 'provider' | 'owner' | 'project' | 'package-manager' | 'multi-ecosystem-update'
+  >;
 };
 export type RunJobResult = { success: true; message?: string } | { success: false; message: string };
 

--- a/packages/core/src/usage.ts
+++ b/packages/core/src/usage.ts
@@ -22,6 +22,7 @@ import { DependabotPackageManagerSchema, DependabotSourceProviderSchema } from '
  *   "started": "2025-10-03T14:44:00.191Z",
  *   "duration": 31812,
  *   "success": true,
+ *   "multi-ecosystem-update": true,
  *   "error": {
  *     "message": "An error occurred"
  *   }
@@ -46,6 +47,7 @@ export const UsageTelemetryRequestDataSchema = z.object({
   'started': z.coerce.date(),
   'duration': z.number().min(0), // in milliseconds
   'success': z.boolean(),
+  'multi-ecosystem-update': z.boolean().optional(),
   'error': z.object({ message: z.string() }).optional(),
 });
 


### PR DESCRIPTION
This includes validating group usage in config, merging effective group/update settings for branching and PR metadata, and propagating `multi-ecosystem-update` through jobs and usage telemetry.