### PR TITLE
Add multi-ecosystem execution planning and PR orchestration

### DIFF
--- a/.changeset/young-loops-rest.md
+++ b/.changeset/young-loops-rest.md
@@ -1,0 +1,18 @@
+---
+"@paklo/core": minor
+---
+
+Add multi-ecosystem execution planning and PR orchestration
+
+Build on the initial multi-ecosystem config and job support by introducing
+execution-unit planning and orchestration for grouped updates.
+
+This change teaches the runner to plan linked updates together, defer
+multi-ecosystem PR creation until all member jobs have finished, and then
+finalize a single consolidated PR with a shared branch, combined body, and
+merged settings.
+
+It also adds PR metadata for the new flow, including explicit
+`Dependabot.PackageManagers` and `Dependabot.MultiEcosystemGroupName` properties,
+while keeping read compatibility for older PRs that only stored
+`Dependabot.PackageManager`.

--- a/packages/core/src/azure/client/constants.ts
+++ b/packages/core/src/azure/client/constants.ts
@@ -10,6 +10,8 @@ export const ANONYMOUS_USER_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
  */
 export const PR_PROPERTY_MICROSOFT_GIT_SOURCE_REF_NAME = 'Microsoft.Git.PullRequest.SourceRefName';
 export const PR_PROPERTY_DEPENDABOT_PACKAGE_MANAGER = 'Dependabot.PackageManager';
+export const PR_PROPERTY_DEPENDABOT_PACKAGE_MANAGERS = 'Dependabot.PackageManagers';
 export const PR_PROPERTY_DEPENDABOT_DEPENDENCIES = 'Dependabot.Dependencies';
+export const PR_PROPERTY_DEPENDABOT_MULTI_ECOSYSTEM_GROUP_NAME = 'Dependabot.MultiEcosystemGroupName';
 
 export const PR_DESCRIPTION_MAX_LENGTH = 4_000;

--- a/packages/core/src/azure/client/utils.test.ts
+++ b/packages/core/src/azure/client/utils.test.ts
@@ -2,10 +2,16 @@ import { describe, expect, it } from 'vitest';
 
 import { type DependabotCreatePullRequest, DependabotPersistedPrSchema, getPersistedPr } from '@/dependabot';
 
-import { PR_PROPERTY_DEPENDABOT_DEPENDENCIES, PR_PROPERTY_DEPENDABOT_PACKAGE_MANAGER } from './constants';
+import {
+  PR_PROPERTY_DEPENDABOT_DEPENDENCIES,
+  PR_PROPERTY_DEPENDABOT_MULTI_ECOSYSTEM_GROUP_NAME,
+  PR_PROPERTY_DEPENDABOT_PACKAGE_MANAGER,
+  PR_PROPERTY_DEPENDABOT_PACKAGE_MANAGERS,
+} from './constants';
 import type { AzdoPrExtractedWithProperties } from './types';
 import {
   buildPullRequestProperties,
+  getPullRequestDependencyGroupName,
   getPullRequestForDependencyNames,
   parsePullRequestProperties,
   parsePullRequestProps,
@@ -117,6 +123,45 @@ describe('parsePullRequestProperties', () => {
     expect(result[1]!.dependencies[0]!['dependency-name']).toBe('express');
   });
 
+  it('matches a pull request persisted under multiple package managers', () => {
+    const prs: AzdoPrExtractedWithProperties[] = [
+      {
+        pullRequestId: 1,
+        properties: [
+          { name: PR_PROPERTY_DEPENDABOT_PACKAGE_MANAGER, value: 'docker' },
+          { name: PR_PROPERTY_DEPENDABOT_PACKAGE_MANAGERS, value: JSON.stringify(['docker', 'terraform']) },
+          {
+            name: PR_PROPERTY_DEPENDABOT_DEPENDENCIES,
+            value: JSON.stringify({
+              'dependency-group-name': 'infrastructure',
+              'dependencies': [{ 'dependency-name': 'nginx' }, { 'dependency-name': 'hashicorp/aws' }],
+            }),
+          },
+        ],
+      },
+    ];
+
+    expect(parsePullRequestProperties(prs, 'docker')).toHaveLength(1);
+    expect(parsePullRequestProperties(prs, 'terraform')).toHaveLength(1);
+  });
+
+  it('falls back to the legacy single package-manager property when needed', () => {
+    const prs: AzdoPrExtractedWithProperties[] = [
+      {
+        pullRequestId: 1,
+        properties: [
+          { name: PR_PROPERTY_DEPENDABOT_PACKAGE_MANAGER, value: 'docker' },
+          {
+            name: PR_PROPERTY_DEPENDABOT_DEPENDENCIES,
+            value: JSON.stringify({ dependencies: [{ 'dependency-name': 'nginx' }] }),
+          },
+        ],
+      },
+    ];
+
+    expect(parsePullRequestProperties(prs, 'docker')).toHaveLength(1);
+  });
+
   it('returns empty array when no matching package manager found', () => {
     const prs: AzdoPrExtractedWithProperties[] = [
       {
@@ -134,6 +179,45 @@ describe('parsePullRequestProperties', () => {
     const result = parsePullRequestProperties(prs, 'nuget');
 
     expect(result).toHaveLength(0);
+  });
+});
+
+describe('getPullRequestDependencyGroupName', () => {
+  it('returns the persisted dependency group name when present', () => {
+    const pr: AzdoPrExtractedWithProperties = {
+      pullRequestId: 1,
+      properties: [
+        { name: PR_PROPERTY_DEPENDABOT_PACKAGE_MANAGER, value: 'docker' },
+        {
+          name: PR_PROPERTY_DEPENDABOT_DEPENDENCIES,
+          value: JSON.stringify({
+            'dependency-group-name': 'infrastructure',
+            'dependencies': [{ 'dependency-name': 'nginx' }],
+          }),
+        },
+      ],
+    };
+
+    expect(getPullRequestDependencyGroupName(pr)).toBe('infrastructure');
+  });
+
+  it('prefers the explicit multi-ecosystem group name when present', () => {
+    const pr: AzdoPrExtractedWithProperties = {
+      pullRequestId: 1,
+      properties: [
+        { name: PR_PROPERTY_DEPENDABOT_PACKAGE_MANAGER, value: 'docker' },
+        { name: PR_PROPERTY_DEPENDABOT_MULTI_ECOSYSTEM_GROUP_NAME, value: 'infrastructure' },
+        {
+          name: PR_PROPERTY_DEPENDABOT_DEPENDENCIES,
+          value: JSON.stringify({
+            'dependency-group-name': 'some-other-group',
+            'dependencies': [{ 'dependency-name': 'nginx' }],
+          }),
+        },
+      ],
+    };
+
+    expect(getPullRequestDependencyGroupName(pr)).toBe('infrastructure');
   });
 });
 
@@ -383,5 +467,35 @@ describe('getPersistedPr and buildPullRequestProperties', () => {
       throw new Error('Expected dependency-group-name to be defined');
     }
     expect(parsed['dependency-group-name']!).toBe('production');
+  });
+
+  it('writes one package-manager property for each persisted ecosystem', () => {
+    const properties = buildPullRequestProperties(
+      ['docker', 'terraform'],
+      {
+        'dependency-group-name': 'infrastructure',
+        'dependencies': [],
+      },
+      'infrastructure',
+    );
+
+    expect(properties.find((property) => property.name === PR_PROPERTY_DEPENDABOT_PACKAGE_MANAGERS)?.value).toBe(
+      JSON.stringify(['docker', 'terraform']),
+    );
+    expect(
+      properties.find((property) => property.name === PR_PROPERTY_DEPENDABOT_MULTI_ECOSYSTEM_GROUP_NAME)?.value,
+    ).toBe('infrastructure');
+    expect(properties.find((property) => property.name === PR_PROPERTY_DEPENDABOT_PACKAGE_MANAGER)).toBeUndefined();
+  });
+
+  it('writes Dependabot.PackageManagers even when only one package manager is present', () => {
+    const properties = buildPullRequestProperties('docker', {
+      dependencies: [],
+    });
+
+    expect(properties.find((property) => property.name === PR_PROPERTY_DEPENDABOT_PACKAGE_MANAGERS)?.value).toBe(
+      JSON.stringify(['docker']),
+    );
+    expect(properties.find((property) => property.name === PR_PROPERTY_DEPENDABOT_PACKAGE_MANAGER)).toBeUndefined();
   });
 });

--- a/packages/core/src/azure/client/utils.ts
+++ b/packages/core/src/azure/client/utils.ts
@@ -4,6 +4,8 @@ import {
   type DependabotCreatePullRequest,
   type DependabotExistingGroupPr,
   type DependabotExistingPr,
+  type DependabotPackageManager,
+  DependabotPackageManagerSchema,
   type DependabotPersistedPr,
   DependabotPersistedPrSchema,
   type DependabotUpdatePullRequest,
@@ -11,12 +13,26 @@ import {
   getDependencyNames,
 } from '@/dependabot';
 
-import { PR_PROPERTY_DEPENDABOT_DEPENDENCIES, PR_PROPERTY_DEPENDABOT_PACKAGE_MANAGER } from './constants';
+import {
+  PR_PROPERTY_DEPENDABOT_DEPENDENCIES,
+  PR_PROPERTY_DEPENDABOT_MULTI_ECOSYSTEM_GROUP_NAME,
+  PR_PROPERTY_DEPENDABOT_PACKAGE_MANAGER,
+  PR_PROPERTY_DEPENDABOT_PACKAGE_MANAGERS,
+} from './constants';
 import type { AzdoFileChange, AzdoPrExtractedWithProperties, AzdoVersionControlChangeType } from './types';
 
-export function buildPullRequestProperties(packageManager: string, dependencies: DependabotPersistedPr) {
+export function buildPullRequestProperties(
+  packageManager: DependabotPackageManager | DependabotPackageManager[],
+  dependencies: DependabotPersistedPr,
+  multiEcosystemGroupName?: string,
+) {
+  const packageManagers = [...new Set(Array.isArray(packageManager) ? packageManager : [packageManager])];
+
   return [
-    { name: PR_PROPERTY_DEPENDABOT_PACKAGE_MANAGER, value: packageManager },
+    { name: PR_PROPERTY_DEPENDABOT_PACKAGE_MANAGERS, value: JSON.stringify(packageManagers) },
+    ...(multiEcosystemGroupName
+      ? [{ name: PR_PROPERTY_DEPENDABOT_MULTI_ECOSYSTEM_GROUP_NAME, value: multiEcosystemGroupName }]
+      : []),
     { name: PR_PROPERTY_DEPENDABOT_DEPENDENCIES, value: JSON.stringify(dependencies) },
   ];
 }
@@ -31,20 +47,63 @@ export function parsePullRequestProps(
   return { 'pr-number': pr.pullRequestId, ...parsed };
 }
 
-function filterPullRequestsByPackageManager(pr: AzdoPrExtractedWithProperties, packageManager: string) {
-  return pr.properties?.find((p) => p.name === PR_PROPERTY_DEPENDABOT_PACKAGE_MANAGER && p.value === packageManager);
+export function getPullRequestDependencyGroupName(pr: AzdoPrExtractedWithProperties): string | null {
+  const multiEcosystemGroupName = pr.properties?.find(
+    (property) => property.name === PR_PROPERTY_DEPENDABOT_MULTI_ECOSYSTEM_GROUP_NAME,
+  )?.value;
+  if (multiEcosystemGroupName) return multiEcosystemGroupName;
+
+  const value = pr.properties?.find((property) => property.name === PR_PROPERTY_DEPENDABOT_DEPENDENCIES)?.value;
+  if (!value) return null;
+
+  try {
+    const parsed = DependabotPersistedPrSchema.parse(JSON.parse(value));
+    return 'dependency-group-name' in parsed ? (parsed['dependency-group-name'] ?? null) : null;
+  } catch {
+    return null;
+  }
+}
+
+function getPullRequestPackageManagers(pr: AzdoPrExtractedWithProperties): DependabotPackageManager[] {
+  const packageManagersValue = pr.properties?.find(
+    (property) => property.name === PR_PROPERTY_DEPENDABOT_PACKAGE_MANAGERS,
+  )?.value;
+  if (packageManagersValue) {
+    try {
+      return DependabotPackageManagerSchema.array().parse(JSON.parse(packageManagersValue));
+    } catch {
+      return [];
+    }
+  }
+
+  // TODO: Remove fallback to Dependabot.PackageManager after July 23, 2026.
+  // Prefer Dependabot.PackageManagers for all reads once old PR metadata has aged out.
+  const packageManagerValue = pr.properties?.find(
+    (property) => property.name === PR_PROPERTY_DEPENDABOT_PACKAGE_MANAGER,
+  )?.value;
+  if (!packageManagerValue) return [];
+
+  const parsed = DependabotPackageManagerSchema.safeParse(packageManagerValue);
+  return parsed.success ? [parsed.data] : [];
+}
+
+function filterPullRequestsByPackageManager(
+  pr: AzdoPrExtractedWithProperties,
+  packageManager: DependabotPackageManager,
+) {
+  return getPullRequestPackageManagers(pr).includes(packageManager);
 }
 
 export function parsePullRequestProperties(
   pullRequests: AzdoPrExtractedWithProperties[],
-  packageManager: string,
+  packageManager: DependabotPackageManager,
 ): (DependabotExistingPr | DependabotExistingGroupPr)[] {
   return pullRequests.filter((pr) => filterPullRequestsByPackageManager(pr, packageManager)).map(parsePullRequestProps);
 }
 
 export function getPullRequestForDependencyNames(
   existingPullRequests: AzdoPrExtractedWithProperties[],
-  packageManager: string,
+  packageManager: DependabotPackageManager,
   dependencyNames: string[],
   dependencyGroupName?: string | null,
 ): AzdoPrExtractedWithProperties | undefined {

--- a/packages/core/src/azure/runner/runner.test.ts
+++ b/packages/core/src/azure/runner/runner.test.ts
@@ -76,6 +76,7 @@ describe('AzureLocalJobsRunner', () => {
     clear: ReturnType<typeof vi.fn>;
     requests: ReturnType<typeof vi.fn>;
     allAffectedPrs: ReturnType<typeof vi.fn>;
+    finalizeUnit: ReturnType<typeof vi.fn>;
   };
 
   beforeEach(() => {
@@ -141,6 +142,7 @@ describe('AzureLocalJobsRunner', () => {
       clear: vi.fn(),
       requests: vi.fn().mockReturnValue([]),
       allAffectedPrs: vi.fn().mockReturnValue([]),
+      finalizeUnit: vi.fn().mockResolvedValue(undefined),
     };
 
     jobsRunner = new TestableAzureLocalJobsRunner(options);
@@ -507,6 +509,116 @@ describe('AzureLocalJobsRunner', () => {
         affectedPrs: [],
       });
       expect(runJob).toHaveBeenCalledTimes(2);
+    });
+
+    it('should keep multi-ecosystem member updates in config order', async () => {
+      vi.mocked(runJob).mockResolvedValue({ success: true, message: 'Job completed successfully' });
+
+      const docker = {
+        'package-ecosystem': 'docker',
+        'directory': '/',
+        'open-pull-requests-limit': 5,
+        'multi-ecosystem-group': 'infrastructure',
+        'patterns': ['*'],
+      } as DependabotUpdate;
+      const terraform = {
+        'package-ecosystem': 'terraform',
+        'directory': '/',
+        'open-pull-requests-limit': 5,
+        'multi-ecosystem-group': 'infrastructure',
+        'patterns': ['*'],
+      } as DependabotUpdate;
+      options.config = {
+        ...options.config,
+        'multi-ecosystem-groups': {
+          infrastructure: {
+            schedule: { interval: 'weekly', day: 'monday', timezone: 'Etc/UTC' },
+          },
+        },
+        'updates': [docker, terraform],
+      } as DependabotConfig;
+
+      jobsRunner = new TestableAzureLocalJobsRunner(options);
+      await jobsRunner.testPerformUpdates(
+        mockServer,
+        options.config.updates,
+        'update',
+        [],
+        'http://localhost:3000/api',
+        'http://localhost:3000/api',
+      );
+
+      expect(mockServer.add.mock.calls[0]![0].update).toBe(docker);
+      expect(mockServer.add.mock.calls[1]![0].update).toBe(terraform);
+      expect(mockServer.add.mock.calls[0]![0].unit).toEqual({
+        kind: 'multi-ecosystem',
+        groupname: 'infrastructure',
+        group: options.config['multi-ecosystem-groups']!.infrastructure,
+        updates: [docker, terraform],
+      });
+      expect(mockServer.add.mock.calls[1]![0].unit).toEqual({
+        kind: 'multi-ecosystem',
+        groupname: 'infrastructure',
+        group: options.config['multi-ecosystem-groups']!.infrastructure,
+        updates: [docker, terraform],
+      });
+      expect(mockServer.finalizeUnit).toHaveBeenCalledWith({
+        kind: 'multi-ecosystem',
+        groupname: 'infrastructure',
+        group: options.config['multi-ecosystem-groups']!.infrastructure,
+        updates: [docker, terraform],
+      });
+      expect(runJob).toHaveBeenCalledTimes(2);
+    });
+
+    it('should add a finalization result for multi-ecosystem execution units', async () => {
+      vi.mocked(runJob).mockResolvedValue({ success: true, message: 'Job completed successfully' });
+      mockServer.finalizeUnit.mockResolvedValue({
+        success: true,
+        affectedPrs: [11],
+      });
+
+      options.config = {
+        ...options.config,
+        'multi-ecosystem-groups': {
+          infrastructure: {
+            schedule: { interval: 'weekly', day: 'monday', timezone: 'Etc/UTC' },
+          },
+        },
+        'updates': [
+          {
+            'package-ecosystem': 'docker',
+            'directory': '/',
+            'open-pull-requests-limit': 5,
+            'multi-ecosystem-group': 'infrastructure',
+            'patterns': ['*'],
+          } as DependabotUpdate,
+          {
+            'package-ecosystem': 'terraform',
+            'directory': '/',
+            'open-pull-requests-limit': 5,
+            'multi-ecosystem-group': 'infrastructure',
+            'patterns': ['*'],
+          } as DependabotUpdate,
+        ],
+      } as DependabotConfig;
+
+      jobsRunner = new TestableAzureLocalJobsRunner(options);
+      const result = await jobsRunner.testPerformUpdates(
+        mockServer,
+        options.config.updates,
+        'update',
+        [],
+        'http://localhost:3000/api',
+        'http://localhost:3000/api',
+      );
+
+      expect(result).toContainEqual({
+        id: 'multi-ecosystem:infrastructure',
+        success: true,
+        message: undefined,
+        affectedPrs: [11],
+      });
     });
 
     it('should return failure when no dependencies found for security updates', async () => {

--- a/packages/core/src/azure/runner/runner.ts
+++ b/packages/core/src/azure/runner/runner.ts
@@ -13,6 +13,7 @@ import {
   DependabotJobBuilder,
   type DependabotJobConfig,
   type DependabotUpdate,
+  createExecutionPlan,
   mapPackageEcosystemToPackageManager,
   normalizeBranchName,
 } from '@/dependabot';
@@ -206,6 +207,7 @@ export class AzureLocalJobsRunner extends LocalJobsRunner {
     } = this;
 
     const results: RunJobsResult = [];
+    const { units } = createExecutionPlan(config, updates);
 
     function makeRandomJobId(): string {
       const array = new Uint32Array(1);
@@ -224,144 +226,61 @@ export class AzureLocalJobsRunner extends LocalJobsRunner {
       };
     }
 
-    for (const update of updates) {
-      const packageEcosystem = update['package-ecosystem'];
-      const packageManager = mapPackageEcosystemToPackageManager(packageEcosystem);
+    for (const unit of units) {
+      const updates = unit.kind === 'single' ? [unit.update] : unit.updates;
+      for (const update of updates) {
+        const packageEcosystem = update['package-ecosystem'];
+        const packageManager = mapPackageEcosystemToPackageManager(packageEcosystem);
 
-      // If there is an updater image, replace the placeholder in it
-      let { updaterImage } = this.options;
-      updaterImage = updaterImage?.replace(/\{ecosystem\}/i, packageEcosystem);
+        // If there is an updater image, replace the placeholder in it
+        let { updaterImage } = this.options;
+        updaterImage = updaterImage?.replace(/\{ecosystem\}/i, packageEcosystem);
 
-      // Parse the Dependabot metadata for the existing pull requests that are related to this update
-      // Dependabot will use this to determine if we need to create new pull requests or update/close existing ones
-      const existingPullRequestsForPackageManager = parsePullRequestProperties(existingPullRequests, packageManager);
+        // Parse the Dependabot metadata for the existing pull requests that are related to this update
+        // Dependabot will use this to determine if we need to create new pull requests or update/close existing ones
+        const existingPullRequestsForPackageManager = parsePullRequestProperties(existingPullRequests, packageManager);
 
-      const builder = new DependabotJobBuilder({
-        experiments,
-        source: {
-          provider: 'azure',
-          ...url,
-          // replacing hostname with host to ensure we capture port if specified
-          // this mostly applies to Azure DevOps Server on-premises instances
-          // where the URL often includes a port number,
-          // e.g. `https://on.prem.com:8080/contoso`
-          // the api-endpoint already has it
-          hostname: url.host,
-        },
-        config,
-        update,
-        systemAccessToken: gitToken,
-        githubToken,
-        debug: false,
-      });
-
-      let job: DependabotJobConfig | undefined;
-      let credentials: DependabotCredential[] | undefined;
-      let jobToken: string;
-      let credentialsToken: string;
-
-      const debug = this.options.debug;
-
-      // If this is a security-only update (i.e. 'open-pull-requests-limit: 0'), then we first need to discover the dependencies
-      // that need updating and check each one for vulnerabilities. This is because Dependabot requires the list of vulnerable dependencies
-      // to be supplied in the job definition of security-only update job, it will not automatically discover them like a versioned update does.
-      // https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates#overriding-the-default-behavior-with-a-configuration-file
-      const securityVulnerabilities: SecurityVulnerability[] = [];
-      const dependencyNamesToUpdate: string[] = [];
-      const openPullRequestsLimit = update['open-pull-requests-limit']!;
-      const securityUpdatesOnly = openPullRequestsLimit === 0;
-      if (securityUpdatesOnly) {
-        // Run an update job to discover all dependencies
-        const id = makeRandomJobId();
-        ({ job, credentials } = builder.forDependenciesList({ id }));
-        ({ jobToken, credentialsToken } = this.makeTokens());
-        server.add({ id, update, job, jobToken, credentialsToken, credentials });
-        await runJob({
-          dependabotApiUrl,
-          dependabotApiDockerUrl,
-          jobId: id,
-          jobToken,
-          credentialsToken,
-          updaterImage,
-          secretMasker,
-          debug,
-          usage: makeUsageData(job),
+        const builder = new DependabotJobBuilder({
+          experiments,
+          source: {
+            provider: 'azure',
+            ...url,
+            // replacing hostname with host to ensure we capture port if specified
+            // this mostly applies to Azure DevOps Server on-premises instances
+            // where the URL often includes a port number,
+            // e.g. `https://on.prem.com:8080/contoso`
+            // the api-endpoint already has it
+            hostname: url.host,
+          },
+          config,
+          update,
+          systemAccessToken: gitToken,
+          githubToken,
+          debug: false,
         });
 
-        const outputs = server.requests(id);
-        const packagesToCheckForVulnerabilities: Package[] | undefined = outputs!
-          .find((o) => o.type === 'update_dependency_list')
-          ?.data.dependencies?.map((d) => ({ name: d.name, version: d.version }));
-        if (packagesToCheckForVulnerabilities?.length) {
-          logger.info(
-            `Detected ${packagesToCheckForVulnerabilities.length} dependencies; Checking for vulnerabilities...`,
-          );
+        let job: DependabotJobConfig | undefined;
+        let credentials: DependabotCredential[] | undefined;
+        let jobToken: string;
+        let credentialsToken: string;
 
-          // parse security advisories from file (private)
-          if (securityAdvisoriesFile) {
-            const filePath = securityAdvisoriesFile;
-            if (existsSync(filePath)) {
-              const fileContents = await readFile(filePath, 'utf-8');
-              securityVulnerabilities.push(
-                ...(await SecurityVulnerabilitySchema.array().parseAsync(JSON.parse(fileContents))),
-              );
-            } else {
-              logger.info(`Private security advisories file '${filePath}' does not exist`);
-            }
-          }
-          if (githubToken) {
-            const ghsaClient = new GitHubSecurityAdvisoryClient(githubToken);
-            const githubVulnerabilities = await ghsaClient.getSecurityVulnerabilitiesAsync(
-              getGhsaPackageEcosystemFromDependabotPackageManager(packageManager),
-              packagesToCheckForVulnerabilities || [],
-            );
-            securityVulnerabilities.push(...githubVulnerabilities);
-          } else {
-            logger.info(
-              'GitHub access token is not provided; Checking for vulnerabilities from GitHub is skipped. ' +
-                'This is not an issue if you are using private security advisories file.',
-            );
-          }
+        const debug = this.options.debug;
 
-          const filtered = filterVulnerabilities(securityVulnerabilities);
-          securityVulnerabilities.splice(0); // clear array
-          securityVulnerabilities.push(...filtered);
-
-          // Only update dependencies that have vulnerabilities
-          dependencyNamesToUpdate.push(...Array.from(new Set(securityVulnerabilities.map((v) => v.package.name))));
-          logger.info(
-            `Detected ${securityVulnerabilities.length} vulnerabilities affecting ${dependencyNamesToUpdate.length} dependencies`,
-          );
-          if (dependencyNamesToUpdate.length) {
-            logger.trace(dependencyNamesToUpdate);
-          }
-        } else {
-          logger.info(`No vulnerabilities detected for update ${update['package-ecosystem']} in ${update.directory}`);
-          server.clear(id);
-          continue; // nothing more to do for this update
-        }
-
-        server.clear(id);
-      }
-
-      // Run an update job for "all dependencies"; this will create new pull requests for dependencies that need updating
-      const openPullRequestsCount = existingPullRequestsForPackageManager.length;
-      const hasReachedOpenPullRequestLimit =
-        openPullRequestsLimit > 0 && openPullRequestsCount >= openPullRequestsLimit;
-      if (!hasReachedOpenPullRequestLimit) {
-        const dependenciesHaveVulnerabilities = dependencyNamesToUpdate.length && securityVulnerabilities.length;
-        if (!securityUpdatesOnly || dependenciesHaveVulnerabilities) {
+        // If this is a security-only update (i.e. 'open-pull-requests-limit: 0'), then we first need to discover the dependencies
+        // that need updating and check each one for vulnerabilities. This is because Dependabot requires the list of vulnerable dependencies
+        // to be supplied in the job definition of security-only update job, it will not automatically discover them like a versioned update does.
+        // https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates#overriding-the-default-behavior-with-a-configuration-file
+        const securityVulnerabilities: SecurityVulnerability[] = [];
+        const dependencyNamesToUpdate: string[] = [];
+        const openPullRequestsLimit = update['open-pull-requests-limit']!;
+        const securityUpdatesOnly = openPullRequestsLimit === 0;
+        if (securityUpdatesOnly) {
+          // Run an update job to discover all dependencies
           const id = makeRandomJobId();
-          ({ job, credentials } = builder.forUpdate({
-            id,
-            command,
-            dependencyNamesToUpdate,
-            existingPullRequests: existingPullRequestsForPackageManager,
-            securityVulnerabilities,
-          }));
+          ({ job, credentials } = builder.forDependenciesList({ id }));
           ({ jobToken, credentialsToken } = this.makeTokens());
-          server.add({ id, update, job, jobToken, credentialsToken, credentials });
-          const { success, message } = await runJob({
+          server.add({ id, unit, update, job, jobToken, credentialsToken, credentials });
+          await runJob({
             dependabotApiUrl,
             dependabotApiDockerUrl,
             jobId: id,
@@ -372,33 +291,77 @@ export class AzureLocalJobsRunner extends LocalJobsRunner {
             debug,
             usage: makeUsageData(job),
           });
-          const affectedPrs = server.allAffectedPrs(id);
-          server.clear(id);
-          results.push({ id, success, message, affectedPrs });
-        } else {
-          logger.info('Nothing to update; dependencies are not affected by any known vulnerability');
-        }
-      } else {
-        logger.warn(
-          `Skipping update for ${packageEcosystem} packages as the open pull requests limit (${openPullRequestsLimit}) has already been reached`,
-        );
-      }
 
-      // If there are existing pull requests, run an update job for each one; this will resolve merge conflicts and close pull requests that are no longer needed
-      const numberOfPullRequestsToUpdate = existingPullRequestsForPackageManager.length;
-      if (numberOfPullRequestsToUpdate > 0) {
-        if (!dryRun) {
-          for (const pullRequestToUpdate of existingPullRequestsForPackageManager) {
+          const outputs = server.requests(id);
+          const packagesToCheckForVulnerabilities: Package[] | undefined = outputs!
+            .find((o) => o.type === 'update_dependency_list')
+            ?.data.dependencies?.map((d) => ({ name: d.name, version: d.version }));
+          if (packagesToCheckForVulnerabilities?.length) {
+            logger.info(
+              `Detected ${packagesToCheckForVulnerabilities.length} dependencies; Checking for vulnerabilities...`,
+            );
+
+            // parse security advisories from file (private)
+            if (securityAdvisoriesFile) {
+              const filePath = securityAdvisoriesFile;
+              if (existsSync(filePath)) {
+                const fileContents = await readFile(filePath, 'utf-8');
+                securityVulnerabilities.push(
+                  ...(await SecurityVulnerabilitySchema.array().parseAsync(JSON.parse(fileContents))),
+                );
+              } else {
+                logger.info(`Private security advisories file '${filePath}' does not exist`);
+              }
+            }
+            if (githubToken) {
+              const ghsaClient = new GitHubSecurityAdvisoryClient(githubToken);
+              const githubVulnerabilities = await ghsaClient.getSecurityVulnerabilitiesAsync(
+                getGhsaPackageEcosystemFromDependabotPackageManager(packageManager),
+                packagesToCheckForVulnerabilities || [],
+              );
+              securityVulnerabilities.push(...githubVulnerabilities);
+            } else {
+              logger.info(
+                'GitHub access token is not provided; Checking for vulnerabilities from GitHub is skipped. ' +
+                  'This is not an issue if you are using private security advisories file.',
+              );
+            }
+
+            const filtered = filterVulnerabilities(securityVulnerabilities);
+            securityVulnerabilities.splice(0); // clear array
+            securityVulnerabilities.push(...filtered);
+
+            // Only update dependencies that have vulnerabilities
+            dependencyNamesToUpdate.push(...Array.from(new Set(securityVulnerabilities.map((v) => v.package.name))));
+            logger.info(
+              `Detected ${securityVulnerabilities.length} vulnerabilities affecting ${dependencyNamesToUpdate.length} dependencies`,
+            );
+            if (dependencyNamesToUpdate.length) {
+              logger.trace(dependencyNamesToUpdate);
+            }
+          } else {
+            logger.info(`No vulnerabilities detected for update ${update['package-ecosystem']} in ${update.directory}`);
+            continue; // nothing more to do for this update
+          }
+        }
+
+        // Run an update job for "all dependencies"; this will create new pull requests for dependencies that need updating
+        const openPullRequestsCount = existingPullRequestsForPackageManager.length;
+        const hasReachedOpenPullRequestLimit =
+          openPullRequestsLimit > 0 && openPullRequestsCount >= openPullRequestsLimit;
+        if (!hasReachedOpenPullRequestLimit) {
+          const dependenciesHaveVulnerabilities = dependencyNamesToUpdate.length && securityVulnerabilities.length;
+          if (!securityUpdatesOnly || dependenciesHaveVulnerabilities) {
             const id = makeRandomJobId();
             ({ job, credentials } = builder.forUpdate({
               id,
               command,
+              dependencyNamesToUpdate,
               existingPullRequests: existingPullRequestsForPackageManager,
-              pullRequestToUpdate,
               securityVulnerabilities,
             }));
             ({ jobToken, credentialsToken } = this.makeTokens());
-            server.add({ id, update, job, jobToken, credentialsToken, credentials });
+            server.add({ id, unit, update, job, jobToken, credentialsToken, credentials });
             const { success, message } = await runJob({
               dependabotApiUrl,
               dependabotApiDockerUrl,
@@ -411,14 +374,56 @@ export class AzureLocalJobsRunner extends LocalJobsRunner {
               usage: makeUsageData(job),
             });
             const affectedPrs = server.allAffectedPrs(id);
-            server.clear(id);
             results.push({ id, success, message, affectedPrs });
+          } else {
+            logger.info('Nothing to update; dependencies are not affected by any known vulnerability');
           }
         } else {
           logger.warn(
-            `Skipping update of ${numberOfPullRequestsToUpdate} existing ${packageEcosystem} package pull request(s) as 'dryRun' is set to 'true'`,
+            `Skipping update for ${packageEcosystem} packages as the open pull requests limit (${openPullRequestsLimit}) has already been reached`,
           );
         }
+
+        // If there are existing pull requests, run an update job for each one; this will resolve merge conflicts and close pull requests that are no longer needed
+        const numberOfPullRequestsToUpdate = existingPullRequestsForPackageManager.length;
+        if (numberOfPullRequestsToUpdate > 0) {
+          if (!dryRun) {
+            for (const pullRequestToUpdate of existingPullRequestsForPackageManager) {
+              const id = makeRandomJobId();
+              ({ job, credentials } = builder.forUpdate({
+                id,
+                command,
+                existingPullRequests: existingPullRequestsForPackageManager,
+                pullRequestToUpdate,
+                securityVulnerabilities,
+              }));
+              ({ jobToken, credentialsToken } = this.makeTokens());
+              server.add({ id, unit, update, job, jobToken, credentialsToken, credentials });
+              const { success, message } = await runJob({
+                dependabotApiUrl,
+                dependabotApiDockerUrl,
+                jobId: id,
+                jobToken,
+                credentialsToken,
+                updaterImage,
+                secretMasker,
+                debug,
+                usage: makeUsageData(job),
+              });
+              const affectedPrs = server.allAffectedPrs(id);
+              results.push({ id, success, message, affectedPrs });
+            }
+          } else {
+            logger.warn(
+              `Skipping update of ${numberOfPullRequestsToUpdate} existing ${packageEcosystem} package pull request(s) as 'dryRun' is set to 'true'`,
+            );
+          }
+        }
+      }
+
+      const finalized = await server.finalizeUnit(unit);
+      if (unit.kind === 'multi-ecosystem' && finalized) {
+        results.push({ id: `multi-ecosystem:${unit.groupname}`, ...finalized });
       }
     }
 

--- a/packages/core/src/azure/runner/server.test.ts
+++ b/packages/core/src/azure/runner/server.test.ts
@@ -5,10 +5,13 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   type AzdoPrExtractedWithProperties,
   type AzureDevOpsClientWrapper,
+  PR_DESCRIPTION_MAX_LENGTH,
   PR_PROPERTY_DEPENDABOT_DEPENDENCIES,
+  PR_PROPERTY_DEPENDABOT_MULTI_ECOSYSTEM_GROUP_NAME,
   PR_PROPERTY_DEPENDABOT_PACKAGE_MANAGER,
+  PR_PROPERTY_DEPENDABOT_PACKAGE_MANAGERS,
 } from '@/azure/client';
-import type { DependabotConfig, DependabotJobBuilderOutput, DependabotUpdate } from '@/dependabot';
+import type { DependabotConfig, DependabotJobBuilderOutput, DependabotUpdate, ExecutionUnit } from '@/dependabot';
 
 import { extractRepositoryUrl } from '../url-parts';
 import { AzureLocalDependabotServer, type AzureLocalDependabotServerOptions } from './server';
@@ -69,6 +72,15 @@ describe('AzureLocalDependabotServer', () => {
   describe('handle', () => {
     let jobBuilderOutput: DependabotJobBuilderOutput;
     let update: DependabotUpdate;
+
+    function makeMultiEcosystemExecutionUnit(updates: DependabotUpdate[]): ExecutionUnit {
+      return {
+        kind: 'multi-ecosystem',
+        groupname: 'infrastructure',
+        group: options.config['multi-ecosystem-groups']!.infrastructure!,
+        updates,
+      };
+    }
 
     beforeEach(() => {
       vi.clearAllMocks();
@@ -255,7 +267,7 @@ describe('AzureLocalDependabotServer', () => {
       expect(approverClient!.approvePullRequest).toHaveBeenCalled();
     });
 
-    it('should use merged multi-ecosystem group settings when creating a pull request', async () => {
+    it('should use merged multi-ecosystem group settings when finalizing a pull request', async () => {
       options.config = {
         'version': 2,
         'multi-ecosystem-groups': {
@@ -282,8 +294,9 @@ describe('AzureLocalDependabotServer', () => {
       server = new AzureLocalDependabotServer(options);
       server.add({
         id: '1',
+        unit: makeMultiEcosystemExecutionUnit([update]),
         update,
-        job: jobBuilderOutput.job,
+        job: { ...jobBuilderOutput.job, 'package-manager': 'docker', 'multi-ecosystem-update': true },
         jobToken: 'test-token',
         credentialsToken: 'test-creds-token',
         credentials: jobBuilderOutput.credentials,
@@ -305,6 +318,11 @@ describe('AzureLocalDependabotServer', () => {
       });
 
       expect(result).toEqual(true);
+      expect(authorClient.createPullRequest).not.toHaveBeenCalled();
+
+      const finalized = await server.finalizeCreateRequests(makeMultiEcosystemExecutionUnit([update]));
+
+      expect(finalized).toEqual({ success: true, affectedPrs: [11] });
       expect(authorClient.getDefaultBranch).not.toHaveBeenCalled();
       expect(authorClient.createPullRequest).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -312,11 +330,323 @@ describe('AzureLocalDependabotServer', () => {
           assignees: ['@platform-team', '@docker-admin'],
           labels: ['infrastructure', 'docker'],
           workItems: ['42'],
+          title: 'chore(deps): Bump the "infrastructure" group with 1 updates across multiple ecosystems',
           source: expect.objectContaining({
-            branch: expect.stringContaining('dependabot-docker-release'),
+            branch: expect.stringMatching(/^dependabot-infrastructure-[a-f0-9]{10}$/),
           }),
         }),
       );
+    });
+
+    it('should aggregate multi-ecosystem create requests by execution unit', async () => {
+      options.config = {
+        'version': 2,
+        'multi-ecosystem-groups': {
+          infrastructure: {
+            schedule: { interval: 'weekly' },
+          },
+        },
+        'updates': [],
+      } as unknown as DependabotConfig;
+
+      const dockerUpdate = {
+        'package-ecosystem': 'docker',
+        'directory': '/',
+        'patterns': ['*'],
+        'multi-ecosystem-group': 'infrastructure',
+      } as DependabotUpdate;
+      const terraformUpdate = {
+        'package-ecosystem': 'terraform',
+        'directory': '/',
+        'patterns': ['*'],
+        'multi-ecosystem-group': 'infrastructure',
+      } as DependabotUpdate;
+
+      server = new AzureLocalDependabotServer(options);
+      server.add({
+        id: 'docker-job',
+        unit: makeMultiEcosystemExecutionUnit([dockerUpdate, terraformUpdate]),
+        update: dockerUpdate,
+        job: {
+          ...jobBuilderOutput.job,
+          'id': 'docker-job',
+          'package-manager': 'docker',
+          'multi-ecosystem-update': true,
+        },
+        jobToken: 'test-token',
+        credentialsToken: 'test-creds-token',
+        credentials: jobBuilderOutput.credentials,
+      });
+      server.add({
+        id: 'terraform-job',
+        unit: makeMultiEcosystemExecutionUnit([dockerUpdate, terraformUpdate]),
+        update: terraformUpdate,
+        job: {
+          ...jobBuilderOutput.job,
+          'id': 'terraform-job',
+          'package-manager': 'terraform',
+          'multi-ecosystem-update': true,
+        },
+        jobToken: 'test-token-2',
+        credentialsToken: 'test-creds-token-2',
+        credentials: jobBuilderOutput.credentials,
+      });
+
+      vi.mocked(authorClient.createPullRequest).mockResolvedValue(11);
+      vi.mocked(authorClient.getDefaultBranch).mockResolvedValue('main');
+
+      await (server as any).handle('docker-job', {
+        type: 'create_pull_request',
+        data: {
+          'base-commit-sha': '1234abcd',
+          'commit-message': 'Update docker dependency',
+          'pr-body': 'Docker body',
+          'pr-title': 'Docker PR',
+          'updated-dependency-files': [],
+          'dependencies': [{ name: 'nginx', version: '1.0.0', requirements: [], directory: '/' }],
+          'dependency-group': { name: 'infrastructure' },
+        },
+      });
+      await (server as any).handle('terraform-job', {
+        type: 'create_pull_request',
+        data: {
+          'base-commit-sha': '1234abcd',
+          'commit-message': 'Update terraform dependency',
+          'pr-body': 'Terraform body',
+          'pr-title': 'Terraform PR',
+          'updated-dependency-files': [],
+          'dependencies': [{ name: 'hashicorp/aws', version: '1.0.0', requirements: [], directory: '/' }],
+          'dependency-group': { name: 'infrastructure' },
+        },
+      });
+
+      expect(server.createRequests('infrastructure')).toMatchObject([
+        { id: 'docker-job', packageManager: 'docker', update: dockerUpdate },
+        { id: 'terraform-job', packageManager: 'terraform', update: terraformUpdate },
+      ]);
+      expect(authorClient.createPullRequest).not.toHaveBeenCalled();
+
+      const finalized = await server.finalizeCreateRequests(
+        makeMultiEcosystemExecutionUnit([dockerUpdate, terraformUpdate]),
+      );
+
+      expect(finalized).toEqual({ success: true, affectedPrs: [11] });
+      expect(authorClient.createPullRequest).toHaveBeenCalledTimes(1);
+      expect(authorClient.createPullRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'chore(deps): Bump the "infrastructure" group with 2 updates across multiple ecosystems',
+          commitMessage: 'Update docker dependency',
+          description: 'Docker body\n\nTerraform body',
+          source: expect.objectContaining({
+            branch: expect.stringMatching(/^dependabot-infrastructure-[a-f0-9]{10}$/),
+          }),
+          properties: expect.arrayContaining([
+            { name: PR_PROPERTY_DEPENDABOT_PACKAGE_MANAGERS, value: JSON.stringify(['docker', 'terraform']) },
+            { name: PR_PROPERTY_DEPENDABOT_MULTI_ECOSYSTEM_GROUP_NAME, value: 'infrastructure' },
+          ]),
+        }),
+      );
+    });
+
+    it('should ignore unrelated ecosystem PRs when enforcing the grouped open pull requests limit', async () => {
+      options.config = {
+        'version': 2,
+        'multi-ecosystem-groups': {
+          infrastructure: {
+            schedule: { interval: 'weekly' },
+          },
+        },
+        'updates': [],
+      } as unknown as DependabotConfig;
+
+      const dockerUpdate = {
+        'package-ecosystem': 'docker',
+        'directory': '/',
+        'patterns': ['*'],
+        'multi-ecosystem-group': 'infrastructure',
+        'open-pull-requests-limit': 1,
+      } as DependabotUpdate;
+      const terraformUpdate = {
+        'package-ecosystem': 'terraform',
+        'directory': '/',
+        'patterns': ['*'],
+        'multi-ecosystem-group': 'infrastructure',
+        'open-pull-requests-limit': 1,
+      } as DependabotUpdate;
+
+      existingPullRequests = [
+        {
+          pullRequestId: 99,
+          properties: [
+            { name: PR_PROPERTY_DEPENDABOT_PACKAGE_MANAGER, value: 'docker' },
+            {
+              name: PR_PROPERTY_DEPENDABOT_DEPENDENCIES,
+              value: JSON.stringify({
+                dependencies: [{ 'dependency-name': 'busybox', 'dependency-version': '1.36.0', 'directory': '/' }],
+              }),
+            },
+          ],
+        },
+      ];
+      options.existingPullRequests = existingPullRequests;
+      server = new AzureLocalDependabotServer(options);
+
+      server.add({
+        id: 'docker-job',
+        unit: makeMultiEcosystemExecutionUnit([dockerUpdate, terraformUpdate]),
+        update: dockerUpdate,
+        job: {
+          ...jobBuilderOutput.job,
+          'id': 'docker-job',
+          'package-manager': 'docker',
+          'multi-ecosystem-update': true,
+        },
+        jobToken: 'test-token',
+        credentialsToken: 'test-creds-token',
+        credentials: jobBuilderOutput.credentials,
+      });
+      server.add({
+        id: 'terraform-job',
+        unit: makeMultiEcosystemExecutionUnit([dockerUpdate, terraformUpdate]),
+        update: terraformUpdate,
+        job: {
+          ...jobBuilderOutput.job,
+          'id': 'terraform-job',
+          'package-manager': 'terraform',
+          'multi-ecosystem-update': true,
+        },
+        jobToken: 'test-token-2',
+        credentialsToken: 'test-creds-token-2',
+        credentials: jobBuilderOutput.credentials,
+      });
+
+      vi.mocked(authorClient.createPullRequest).mockResolvedValue(11);
+      vi.mocked(authorClient.getDefaultBranch).mockResolvedValue('main');
+
+      await (server as any).handle('docker-job', {
+        type: 'create_pull_request',
+        data: {
+          'base-commit-sha': '1234abcd',
+          'commit-message': 'Update docker dependency',
+          'pr-body': 'Docker body',
+          'pr-title': 'Docker PR',
+          'updated-dependency-files': [],
+          'dependencies': [{ name: 'nginx', version: '1.0.0', requirements: [], directory: '/' }],
+          'dependency-group': { name: 'infrastructure' },
+        },
+      });
+      await (server as any).handle('terraform-job', {
+        type: 'create_pull_request',
+        data: {
+          'base-commit-sha': '1234abcd',
+          'commit-message': 'Update terraform dependency',
+          'pr-body': 'Terraform body',
+          'pr-title': 'Terraform PR',
+          'updated-dependency-files': [],
+          'dependencies': [{ name: 'hashicorp/aws', version: '1.0.0', requirements: [], directory: '/' }],
+          'dependency-group': { name: 'infrastructure' },
+        },
+      });
+
+      const finalized = await server.finalizeCreateRequests(
+        makeMultiEcosystemExecutionUnit([dockerUpdate, terraformUpdate]),
+      );
+
+      expect(finalized).toEqual({ success: true, affectedPrs: [11] });
+      expect(authorClient.createPullRequest).toHaveBeenCalledTimes(1);
+    });
+
+    it('should truncate multi-ecosystem pull request descriptions to the Azure limit', async () => {
+      options.config = {
+        'version': 2,
+        'multi-ecosystem-groups': {
+          infrastructure: {
+            schedule: { interval: 'weekly' },
+          },
+        },
+        'updates': [],
+      } as unknown as DependabotConfig;
+
+      const dockerUpdate = {
+        'package-ecosystem': 'docker',
+        'directory': '/',
+        'patterns': ['*'],
+        'multi-ecosystem-group': 'infrastructure',
+      } as DependabotUpdate;
+      const terraformUpdate = {
+        'package-ecosystem': 'terraform',
+        'directory': '/',
+        'patterns': ['*'],
+        'multi-ecosystem-group': 'infrastructure',
+      } as DependabotUpdate;
+
+      server = new AzureLocalDependabotServer(options);
+      server.add({
+        id: 'docker-job',
+        unit: makeMultiEcosystemExecutionUnit([dockerUpdate, terraformUpdate]),
+        update: dockerUpdate,
+        job: {
+          ...jobBuilderOutput.job,
+          'id': 'docker-job',
+          'package-manager': 'docker',
+          'multi-ecosystem-update': true,
+        },
+        jobToken: 'test-token',
+        credentialsToken: 'test-creds-token',
+        credentials: jobBuilderOutput.credentials,
+      });
+      server.add({
+        id: 'terraform-job',
+        unit: makeMultiEcosystemExecutionUnit([dockerUpdate, terraformUpdate]),
+        update: terraformUpdate,
+        job: {
+          ...jobBuilderOutput.job,
+          'id': 'terraform-job',
+          'package-manager': 'terraform',
+          'multi-ecosystem-update': true,
+        },
+        jobToken: 'test-token-2',
+        credentialsToken: 'test-creds-token-2',
+        credentials: jobBuilderOutput.credentials,
+      });
+
+      vi.mocked(authorClient.createPullRequest).mockResolvedValue(11);
+      vi.mocked(authorClient.getDefaultBranch).mockResolvedValue('main');
+
+      await (server as any).handle('docker-job', {
+        type: 'create_pull_request',
+        data: {
+          'base-commit-sha': '1234abcd',
+          'commit-message': 'Update docker dependency',
+          'pr-body': 'A'.repeat(3500),
+          'pr-title': 'Docker PR',
+          'updated-dependency-files': [],
+          'dependencies': [{ name: 'nginx', version: '1.0.0', requirements: [], directory: '/' }],
+          'dependency-group': { name: 'infrastructure' },
+        },
+      });
+      await (server as any).handle('terraform-job', {
+        type: 'create_pull_request',
+        data: {
+          'base-commit-sha': '1234abcd',
+          'commit-message': 'Update terraform dependency',
+          'pr-body': 'B'.repeat(3500),
+          'pr-title': 'Terraform PR',
+          'updated-dependency-files': [],
+          'dependencies': [{ name: 'hashicorp/aws', version: '1.0.0', requirements: [], directory: '/' }],
+          'dependency-group': { name: 'infrastructure' },
+        },
+      });
+
+      await server.finalizeCreateRequests(makeMultiEcosystemExecutionUnit([dockerUpdate, terraformUpdate]));
+
+      expect(authorClient.createPullRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          description: expect.any(String),
+        }),
+      );
+      const description = vi.mocked(authorClient.createPullRequest).mock.calls[0]![0].description!;
+      expect(description.length).toBe(PR_DESCRIPTION_MAX_LENGTH);
     });
 
     it('should skip processing "update_pull_request" if "dryRun" is true', async () => {

--- a/packages/core/src/azure/runner/server.ts
+++ b/packages/core/src/azure/runner/server.ts
@@ -5,12 +5,15 @@ import {
   PR_DESCRIPTION_MAX_LENGTH,
   buildPullRequestProperties,
   getPullRequestChangedFiles,
+  getPullRequestDependencyGroupName,
   getPullRequestForDependencyNames,
   parsePullRequestProperties,
 } from '@/azure/client';
 import {
   type DependabotConfig,
   type DependabotRequest,
+  type ExecutionUnit,
+  getBranchNameForMultiEcosystemGroup,
   getBranchNameForUpdate,
   getEffectiveUpdateSettings,
   getPersistedPr,
@@ -18,7 +21,7 @@ import {
   getPullRequestDescription,
   shouldSupersede,
 } from '@/dependabot';
-import { LocalDependabotServer, type LocalDependabotServerOptions } from '@/local';
+import { type FinalizeCreateRequestsResult, LocalDependabotServer, type LocalDependabotServerOptions } from '@/local';
 import { logger } from '@/logger';
 
 import { type AzureDevOpsRepositoryUrl } from '../url-parts';
@@ -42,6 +45,160 @@ export class AzureLocalDependabotServer extends LocalDependabotServer {
   constructor(options: AzureLocalDependabotServerOptions) {
     super(options);
     this.options = options;
+  }
+
+  override async finalizeCreateRequests(unit: ExecutionUnit): Promise<FinalizeCreateRequestsResult | undefined> {
+    if (unit.kind !== 'multi-ecosystem') return undefined;
+
+    const { groupname } = unit;
+    const pending = this.createRequests(groupname);
+    if (!pending?.length) return undefined;
+
+    const {
+      url,
+      authorClient,
+      approverClient,
+      existingBranchNames,
+      existingPullRequests,
+      autoApprove,
+      mergeStrategy,
+      setAutoComplete,
+      autoCompleteIgnoreConfigIds,
+      author,
+      dryRun,
+      config,
+    } = this.options;
+    const { project, repository } = url;
+
+    const first = pending[0]!;
+    const allDependencies = pending.flatMap((entry) => entry.request.dependencies);
+    const allPersistedDependencies = pending.flatMap((entry) => getPersistedPr(entry.request).dependencies);
+    const changedFilesByPath = new Map<string, ReturnType<typeof getPullRequestChangedFiles>[number]>();
+    for (const entry of pending) {
+      for (const file of getPullRequestChangedFiles(entry.request)) {
+        changedFilesByPath.set(file.path, file);
+      }
+    }
+
+    const mergedSettings = pending.reduce(
+      (acc, entry) => {
+        const effective = getEffectiveUpdateSettings(config, entry.update);
+        acc.assignees = Array.from(new Set([...acc.assignees, ...(effective.assignees ?? [])]));
+        acc.labels = Array.from(new Set([...acc.labels, ...(effective.labels ?? [])]));
+        acc.milestone ??= effective.milestone;
+        acc['target-branch'] ??= effective['target-branch'];
+        acc['pull-request-branch-name'] ??= effective['pull-request-branch-name'];
+        return acc;
+      },
+      {
+        'assignees': [] as string[],
+        'labels': [] as string[],
+        'milestone': undefined as string | undefined,
+        'target-branch': undefined as string | undefined,
+        'pull-request-branch-name': undefined as { separator?: string } | undefined,
+      },
+    );
+
+    const dependencyGroupName = first.request['dependency-group']?.name || groupname;
+    if (dryRun) {
+      return {
+        success: true,
+        message: `Skipping pull request creation of '${dependencyGroupName}' as 'dryRun' is set to 'true'`,
+        affectedPrs: [],
+      };
+    }
+
+    const openPullRequestsLimit = Math.min(...pending.map((entry) => entry.update['open-pull-requests-limit']!));
+    const packageManagers = [...new Set(pending.map((entry) => entry.packageManager))];
+    const existingPullRequestsCount = new Set(
+      existingPullRequests
+        .filter((pr) => getPullRequestDependencyGroupName(pr) === dependencyGroupName)
+        .map((pr) => pr.pullRequestId),
+    ).size;
+    if (openPullRequestsLimit > 0 && existingPullRequestsCount >= openPullRequestsLimit) {
+      return {
+        success: true,
+        message: `Skipping pull request creation of '${dependencyGroupName}' as the open pull requests limit (${openPullRequestsLimit}) has been reached`,
+        affectedPrs: [],
+      };
+    }
+
+    const targetBranch =
+      mergedSettings['target-branch'] || (await authorClient.getDefaultBranch({ project, repository }));
+    const sourceBranch = getBranchNameForMultiEcosystemGroup({
+      groupname: dependencyGroupName,
+      dependencies: allPersistedDependencies,
+      separator: mergedSettings['pull-request-branch-name']?.separator ?? '-',
+    });
+
+    const existingBranch = existingBranchNames?.find((branch) => sourceBranch === branch) || [];
+    if (existingBranch.length) {
+      return {
+        success: false,
+        message: `Source branch '${sourceBranch}' already exists`,
+        affectedPrs: [],
+      };
+    }
+
+    const combinedTitle = `chore(deps): Bump the "${dependencyGroupName}" group with ${pending.length} updates across multiple ecosystems`;
+    const combinedBody = pending
+      .map((entry) => entry.request['pr-body']?.trim())
+      .filter((body) => body && body.length > 0)
+      .join('\n\n');
+    const description = getPullRequestDescription({
+      packageManager: first.packageManager,
+      body: combinedBody,
+      dependencies: allDependencies,
+      maxDescriptionLength: PR_DESCRIPTION_MAX_LENGTH,
+    });
+
+    const newPullRequestId = await authorClient.createPullRequest({
+      project,
+      repository,
+      source: {
+        commit: first.request['base-commit-sha'],
+        branch: sourceBranch,
+      },
+      target: {
+        branch: targetBranch!,
+      },
+      author,
+      title: combinedTitle,
+      description,
+      commitMessage: first.request['commit-message'],
+      autoComplete: setAutoComplete
+        ? {
+            ignorePolicyConfigIds: autoCompleteIgnoreConfigIds,
+            mergeStrategy: mergeStrategy ?? 'squash',
+          }
+        : undefined,
+      assignees: mergedSettings.assignees,
+      labels: mergedSettings.labels.map((label) => label?.trim()),
+      workItems: mergedSettings.milestone ? [mergedSettings.milestone] : [],
+      changes: Array.from(changedFilesByPath.values()),
+      properties: buildPullRequestProperties(
+        packageManagers,
+        {
+          'dependency-group-name': dependencyGroupName,
+          'dependencies': allPersistedDependencies,
+        },
+        groupname,
+      ),
+    });
+
+    if (!newPullRequestId) {
+      return { success: false, message: 'Failed to create multi-ecosystem pull request', affectedPrs: [] };
+    }
+
+    if (autoApprove && approverClient) {
+      await approverClient.approvePullRequest({
+        project,
+        repository,
+        pullRequestId: newPullRequestId,
+      });
+    }
+
+    return { success: true, affectedPrs: [newPullRequestId] };
   }
 
   protected override async handle(id: string, request: DependabotRequest): Promise<boolean> {
@@ -72,8 +229,14 @@ export class AzureLocalDependabotServer extends LocalDependabotServer {
       logger.error(`No job found for ID '${id}', cannot process request of type '${type}'`);
       return false;
     }
-    const { 'package-manager': packageManager } = job;
+    const unit = this.unit(id);
+    if (request.type === 'create_pull_request' && job['multi-ecosystem-update'] && unit?.kind === 'multi-ecosystem') {
+      // Multi-ecosystem PR creation is deferred until all member jobs in the execution unit have finished.
+      this.queueCreateRequest(id, request.data);
+      return true;
+    }
 
+    const { 'package-manager': packageManager } = job;
     const update = this.update(id)!; // exists because job exists
     const effective = getEffectiveUpdateSettings(config, update);
     const { project, repository } = url;

--- a/packages/core/src/dependabot/branch-name.test.ts
+++ b/packages/core/src/dependabot/branch-name.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { getBranchNameForUpdate, sanitizeRef } from './branch-name';
+import { getBranchNameForMultiEcosystemGroup, getBranchNameForUpdate, sanitizeRef } from './branch-name';
 
 describe('getBranchNameForUpdate', () => {
   it('generates correct branch name for a single dependency update', () => {
@@ -157,6 +157,19 @@ describe('getBranchNameForUpdate', () => {
     });
 
     expect(result).toBe('dependabot/npm/main/mobile-app/lodash-4.17.21');
+  });
+
+  it('generates shared branch name for a multi-ecosystem group', () => {
+    const result = getBranchNameForMultiEcosystemGroup({
+      groupname: 'infrastructure',
+      dependencies: [
+        { 'dependency-name': 'nginx', 'dependency-version': '1.29.8' },
+        { 'dependency-name': 'hashicorp/aws', 'dependency-version': '6.4.0' },
+        { 'dependency-name': 'terraform-aws-modules/vpc/aws', 'dependency-version': '6.6.1' },
+      ],
+    });
+
+    expect(result).toMatch(/^dependabot-infrastructure-[a-f0-9]{10}$/);
   });
 });
 

--- a/packages/core/src/dependabot/branch-name.ts
+++ b/packages/core/src/dependabot/branch-name.ts
@@ -4,6 +4,18 @@ import type { PackageEcosystem } from './config';
 import type { DependabotExistingPrDependency } from './job';
 import { isDependencyRemoved } from './utils';
 
+function getDependencyDigest(dependencies: DependabotExistingPrDependency[]): string {
+  return crypto
+    .createHash('md5')
+    .update(
+      dependencies
+        .map((d) => `${d['dependency-name']}-${isDependencyRemoved(d) ? 'removed' : (d['dependency-version'] ?? '')}`)
+        .join(','),
+    )
+    .digest('hex')
+    .substring(0, 10);
+}
+
 export function getBranchNameForUpdate({
   packageEcosystem,
   targetBranchName,
@@ -41,16 +53,7 @@ export function getBranchNameForUpdate({
   if (branchNameMightBeTooLong) {
     // Group/multi dependency update
     // e.g. dependabot/nuget/main/microsoft-3b49c54d9e
-    const dependencyDigest = crypto
-      .createHash('md5')
-      .update(
-        dependencies
-          .map((d) => `${d['dependency-name']}-${isDependencyRemoved(d) ? 'removed' : (d['dependency-version'] ?? '')}`)
-          .join(','),
-      )
-      .digest('hex')
-      .substring(0, 10);
-    branchName = `${dependencyGroupName || 'multi'}-${dependencyDigest}`;
+    branchName = `${dependencyGroupName || 'multi'}-${getDependencyDigest(dependencies)}`;
   } else {
     // Single dependency update
     // e.g. dependabot/nuget/main/Microsoft.Extensions.Logging-1.0.0
@@ -79,6 +82,18 @@ export function getBranchNameForUpdate({
     ],
     separator,
   );
+}
+
+export function getBranchNameForMultiEcosystemGroup({
+  groupname,
+  dependencies,
+  separator = '-',
+}: {
+  groupname: string;
+  dependencies: DependabotExistingPrDependency[];
+  separator?: string;
+}): string {
+  return sanitizeRef(['dependabot', `${groupname}-${getDependencyDigest(dependencies)}`], separator);
 }
 
 export function sanitizeRef(refParts: (string | undefined)[], separator: string): string {

--- a/packages/core/src/dependabot/execution-plan.test.ts
+++ b/packages/core/src/dependabot/execution-plan.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+
+import type { DependabotConfig, DependabotUpdate } from '@/dependabot';
+
+import { createExecutionPlan } from './execution-plan';
+
+describe('createExecutionPlan', () => {
+  it('creates one unit per standalone update', () => {
+    const updates = [
+      {
+        'package-ecosystem': 'npm',
+        'directory': '/',
+        'schedule': { interval: 'daily' },
+      },
+      {
+        'package-ecosystem': 'docker',
+        'directory': '/',
+        'schedule': { interval: 'weekly' },
+      },
+    ] as DependabotUpdate[];
+
+    const { units } = createExecutionPlan({} as Pick<DependabotConfig, 'multi-ecosystem-groups'>, updates);
+
+    expect(units).toEqual([
+      { kind: 'single', update: updates[0] },
+      { kind: 'single', update: updates[1] },
+    ]);
+  });
+
+  it('groups multi-ecosystem updates by group name', () => {
+    const config = {
+      'multi-ecosystem-groups': {
+        infrastructure: {
+          schedule: { interval: 'weekly', day: 'monday', timezone: 'Etc/UTC' },
+        },
+      },
+    } as unknown as Pick<DependabotConfig, 'multi-ecosystem-groups'>;
+    const docker = {
+      'package-ecosystem': 'docker',
+      'directory': '/',
+      'multi-ecosystem-group': 'infrastructure',
+      'patterns': ['*'],
+    } as DependabotUpdate;
+    const terraform = {
+      'package-ecosystem': 'terraform',
+      'directory': '/',
+      'multi-ecosystem-group': 'infrastructure',
+      'patterns': ['*'],
+    } as DependabotUpdate;
+
+    const { units } = createExecutionPlan(config, [docker, terraform]);
+
+    expect(units).toEqual([
+      {
+        kind: 'multi-ecosystem',
+        groupname: 'infrastructure',
+        group: config['multi-ecosystem-groups']!.infrastructure,
+        updates: [docker, terraform],
+      },
+    ]);
+  });
+
+  it('preserves first-seen unit order while collecting later group members', () => {
+    const config = {
+      'multi-ecosystem-groups': {
+        infrastructure: {
+          schedule: { interval: 'weekly', day: 'monday', timezone: 'Etc/UTC' },
+        },
+      },
+    } as unknown as Pick<DependabotConfig, 'multi-ecosystem-groups'>;
+    const docker = {
+      'package-ecosystem': 'docker',
+      'directory': '/',
+      'multi-ecosystem-group': 'infrastructure',
+      'patterns': ['*'],
+    } as DependabotUpdate;
+    const npm = {
+      'package-ecosystem': 'npm',
+      'directory': '/',
+      'schedule': { interval: 'daily' },
+    } as DependabotUpdate;
+    const terraform = {
+      'package-ecosystem': 'terraform',
+      'directory': '/',
+      'multi-ecosystem-group': 'infrastructure',
+      'patterns': ['*'],
+    } as DependabotUpdate;
+
+    const { units } = createExecutionPlan(config, [docker, npm, terraform]);
+
+    expect(units).toEqual([
+      {
+        kind: 'multi-ecosystem',
+        groupname: 'infrastructure',
+        group: config['multi-ecosystem-groups']!.infrastructure,
+        updates: [docker, terraform],
+      },
+      { kind: 'single', update: npm },
+    ]);
+  });
+});

--- a/packages/core/src/dependabot/execution-plan.ts
+++ b/packages/core/src/dependabot/execution-plan.ts
@@ -1,0 +1,53 @@
+import { type DependabotConfig, type DependabotMultiEcosystemGroup, type DependabotUpdate } from './config';
+
+export type ExecutionUnitSingle = {
+  kind: 'single';
+  update: DependabotUpdate;
+};
+
+export type ExecutionUnitMultiEcosystem = {
+  kind: 'multi-ecosystem';
+  groupname: string;
+  group: DependabotMultiEcosystemGroup;
+  updates: DependabotUpdate[];
+};
+
+export type ExecutionUnit = ExecutionUnitSingle | ExecutionUnitMultiEcosystem;
+
+export function createExecutionPlan(
+  config: Pick<DependabotConfig, 'multi-ecosystem-groups'>,
+  updates: DependabotUpdate[],
+): { units: ExecutionUnit[] } {
+  const units: ExecutionUnit[] = [];
+
+  for (const update of updates) {
+    const groupname = update['multi-ecosystem-group'];
+    if (!groupname) {
+      units.push({ kind: 'single', update });
+      continue;
+    }
+
+    // Keep the unit where the group first appeared so execution follows config order.
+    const existing = units.find((unit) => unit.kind === 'multi-ecosystem' && unit.groupname === groupname);
+    if (existing && existing.kind === 'multi-ecosystem') {
+      existing.updates.push(update);
+      continue;
+    }
+
+    const group = config['multi-ecosystem-groups']?.[groupname];
+    if (!group) {
+      throw new Error(
+        `Update belongs to multi-ecosystem group '${groupname}' but no matching group configuration was found. Please ensure the group is defined in the 'multi-ecosystem-groups' section of the config.`,
+      );
+    }
+
+    units.push({
+      kind: 'multi-ecosystem',
+      groupname,
+      group,
+      updates: [update],
+    });
+  }
+
+  return { units };
+}

--- a/packages/core/src/dependabot/index.ts
+++ b/packages/core/src/dependabot/index.ts
@@ -2,6 +2,7 @@ export * from './author';
 export * from './branch-name';
 export * from './config';
 export * from './directory-key';
+export * from './execution-plan';
 export * from './experiments';
 export * from './job';
 export * from './job-builder';

--- a/packages/core/src/local/server.ts
+++ b/packages/core/src/local/server.ts
@@ -3,12 +3,15 @@ import type { AddressInfo } from 'node:net';
 import { createAdaptorServer } from '@hono/node-server';
 
 import {
+  type DependabotCreatePullRequest,
   type DependabotCredential,
   type DependabotExistingGroupPr,
   type DependabotExistingPr,
   type DependabotJobConfig,
+  type DependabotPackageManager,
   type DependabotRequest,
   type DependabotUpdate,
+  type ExecutionUnit,
   type GitAuthor,
 } from '@/dependabot';
 import { logger } from '@/logger';
@@ -18,6 +21,8 @@ import { type CreateApiServerAppOptions, type DependabotTokenType, createApiServ
 export type LocalDependabotServerAddOptions = {
   /** The ID of the dependabot job. */
   id: string;
+  /** The execution unit this job belongs to. */
+  unit?: ExecutionUnit;
   /** The dependabot update associated with the job. */
   update: DependabotUpdate;
   /** The dependabot job configuration. */
@@ -36,6 +41,19 @@ export type AffectedPullRequestIds = {
   closed: number[];
 };
 
+export type PendingCreatePullRequest = {
+  id: string;
+  packageManager: DependabotPackageManager;
+  update: DependabotUpdate;
+  request: DependabotCreatePullRequest;
+};
+
+export type FinalizeCreateRequestsResult = {
+  success: boolean;
+  message?: string;
+  affectedPrs: number[];
+};
+
 export type LocalDependabotServerOptions = Omit<
   CreateApiServerAppOptions,
   'authenticate' | 'getJob' | 'getCredentials' | 'handle'
@@ -51,8 +69,11 @@ export abstract class LocalDependabotServer {
   private readonly updates = new Map<string, DependabotUpdate>();
   private readonly jobTokens = new Map<string, string>();
   private readonly credentialTokens = new Map<string, string>();
+  private readonly units = new Map<string, ExecutionUnit>();
+  private readonly unitJobIds = new Map<ExecutionUnit, string[]>();
   private readonly jobCredentials = new Map<string, DependabotCredential[]>();
   private readonly receivedRequests = new Map<string, DependabotRequest[]>();
+  private readonly pendingCreatePullRequests = new Map<string, PendingCreatePullRequest[]>();
 
   protected readonly affectedPullRequestIds = new Map<string, AffectedPullRequestIds>();
 
@@ -108,12 +129,13 @@ export abstract class LocalDependabotServer {
    * @param value - The dependabot job details.
    */
   add(value: LocalDependabotServerAddOptions) {
-    const { id, update, job, jobToken, credentialsToken, credentials } = value;
+    const { id, unit, update, job, jobToken, credentialsToken, credentials } = value;
     const {
       trackedJobs,
       updates,
       jobTokens,
       credentialTokens,
+      units,
       jobCredentials,
       receivedRequests,
       affectedPullRequestIds,
@@ -122,6 +144,12 @@ export abstract class LocalDependabotServer {
     updates.set(id, update);
     jobTokens.set(id, jobToken);
     credentialTokens.set(id, credentialsToken);
+    if (unit) {
+      units.set(id, unit);
+      const jobIdsForUnit = this.unitJobIds.get(unit) ?? [];
+      jobIdsForUnit.push(id);
+      this.unitJobIds.set(unit, jobIdsForUnit);
+    }
     jobCredentials.set(id, credentials);
     receivedRequests.set(id, []);
     affectedPullRequestIds.set(id, { created: [], updated: [], closed: [] });
@@ -153,6 +181,77 @@ export abstract class LocalDependabotServer {
   token(id: string, type: DependabotTokenType): string | undefined {
     return type === 'job' ? this.jobTokens.get(id) : this.credentialTokens.get(id);
   }
+
+  /**
+   * Gets the execution unit associated with a dependabot job by ID.
+   * @param id - The ID of the dependabot job.
+   * @returns The execution unit, or undefined if not found.
+   */
+  unit(id: string): ExecutionUnit | undefined {
+    return this.units.get(id);
+  }
+
+  /**
+   * Gets deferred multi-ecosystem create-pull-request requests for a group.
+   * @param groupname - The multi-ecosystem group name.
+   * @returns The queued create-pull-request requests for the group.
+   */
+  createRequests(groupname: string): PendingCreatePullRequest[] {
+    return this.pendingCreatePullRequests.get(groupname) ?? [];
+  }
+
+  /**
+   * Queues a create-pull-request request until the whole multi-ecosystem execution unit finishes.
+   * @param id - The ID of the dependabot job.
+   * @param request - The create-pull-request payload to queue.
+   * @returns Whether the request was queued.
+   */
+  queueCreateRequest(id: string, request: DependabotCreatePullRequest): boolean {
+    const job = this.trackedJobs.get(id);
+    const update = this.updates.get(id);
+    const unit = this.units.get(id);
+    if (!job || !update || unit?.kind !== 'multi-ecosystem') return false;
+
+    const pending = this.pendingCreatePullRequests.get(unit.groupname) ?? [];
+    pending.push({ id, packageManager: job['package-manager'], update, request });
+    this.pendingCreatePullRequests.set(unit.groupname, pending);
+    return true;
+  }
+
+  /**
+   * Finalizes an execution unit and clears any server-side state associated with it.
+   * @param unit - The execution unit to finalize.
+   * @returns The provider finalization result, or undefined when there is nothing to finalize.
+   */
+  async finalizeUnit(unit: ExecutionUnit): Promise<FinalizeCreateRequestsResult | undefined> {
+    try {
+      return await this.finalizeCreateRequests(unit);
+    } finally {
+      const jobIds = this.unitJobIds.get(unit) ?? [];
+      for (const id of jobIds) {
+        // Clear all state associated with jobs in this execution unit.
+        this.trackedJobs.delete(id);
+        this.updates.delete(id);
+        this.jobTokens.delete(id);
+        this.credentialTokens.delete(id);
+        this.units.delete(id);
+        this.jobCredentials.delete(id);
+        this.receivedRequests.delete(id);
+        this.affectedPullRequestIds.delete(id);
+      }
+      this.unitJobIds.delete(unit);
+      if (unit.kind === 'multi-ecosystem') {
+        this.pendingCreatePullRequests.delete(unit.groupname);
+      }
+    }
+  }
+
+  /**
+   * Finalizes deferred create-pull-request requests for an execution unit.
+   * @param unit - The execution unit whose deferred requests should be finalized.
+   * @returns The finalization result, or undefined when there is nothing to finalize.
+   */
+  abstract finalizeCreateRequests(unit: ExecutionUnit): Promise<FinalizeCreateRequestsResult | undefined>;
 
   /**
    * Gets the credentials for a dependabot job by ID.
@@ -191,21 +290,6 @@ export abstract class LocalDependabotServer {
     const affected = this.affectedPrs(id);
     if (!affected) return [];
     return [...affected.created.map((pr) => pr['pr-number']), ...affected.updated, ...affected.closed];
-  }
-
-  /**
-   * Clears all data associated with a dependabot job by ID.
-   * This should be called when the job is no longer needed.
-   * @param id - The ID of the dependabot job to clear.
-   */
-  clear(id: string) {
-    this.trackedJobs.delete(id);
-    this.updates.delete(id);
-    this.jobTokens.delete(id);
-    this.credentialTokens.delete(id);
-    this.jobCredentials.delete(id);
-    this.receivedRequests.delete(id);
-    this.affectedPullRequestIds.delete(id);
   }
 
   /**


### PR DESCRIPTION
Build on the initial multi-ecosystem config and job support by introducing execution-unit planning and orchestration for grouped updates.

This change teaches the runner to plan linked updates together, defer multi-ecosystem PR creation until all member jobs have finished, and then finalize a single consolidated PR with a shared branch, combined body, and merged settings.

It also adds PR metadata for the new flow, including explicit `Dependabot.PackageManagers` and `Dependabot.MultiEcosystemGroupName` properties, while keeping read compatibility for older PRs that only stored `Dependabot.PackageManager`.