### PR TITLE
Support security advisories from github when using uv as package ecosystem

### DIFF
--- a/.changeset/open-papayas-mate.md
+++ b/.changeset/open-papayas-mate.md
@@ -1,0 +1,5 @@
+---
+"@paklo/core": patch
+---
+
+Support security advisories from github when using uv as package ecosystem

--- a/packages/core/src/github/ghsa.ts
+++ b/packages/core/src/github/ghsa.ts
@@ -178,7 +178,7 @@ export function getGhsaPackageEcosystemFromDependabotPackageManager(
       return 'NUGET';
     case 'pip':
       return 'PIP';
-    case: 'uv':
+    case 'uv':
       return 'PIP';
     case 'pub':
       return 'PUB';

--- a/packages/core/src/github/ghsa.ts
+++ b/packages/core/src/github/ghsa.ts
@@ -178,6 +178,8 @@ export function getGhsaPackageEcosystemFromDependabotPackageManager(
       return 'NUGET';
     case 'pip':
       return 'PIP';
+    case: 'uv':
+      return 'PIP';
     case 'pub':
       return 'PUB';
     case 'bundler':


### PR DESCRIPTION
When using `package-ecosystem: "uv"` in combination with a github connection for GitHub advisories, I get the error message:

```
##[error]Unknown dependabot package manager: uv
##[error]An unhandled exception occurred: Error: Unknown dependabot package manager: uv
```

This PR should resolve the issue by updating the function `getGhsaPackageEcosystemFromDependabotPackageManager` to map the `uv` package ecosystem to `PIP` ecosystem supported by GitHub graphQL.