### PR TITLE
Restrict `--cutoff` to Go duration units supported by Docker (`ns`, `us`, `ms`, `s`, `m`, `h`).

### DIFF
--- a/.changeset/swift-wolves-trade.md
+++ b/.changeset/swift-wolves-trade.md
@@ -1,0 +1,7 @@
+---
+"@paklo/core": patch
+"@paklo/cli": patch
+---
+
+Restrict `--cutoff` to Go duration units supported by Docker (`ns`, `us`, `ms`, `s`, `m`, `h`).
+Previously the schema allowed `d`, `w`, and `y` which Docker's `until` filter does not accept, causing a 500 error at runtime.

--- a/packages/cli/src/commands/dependabot/cleanup.ts
+++ b/packages/cli/src/commands/dependabot/cleanup.ts
@@ -4,7 +4,8 @@ import { z } from 'zod';
 
 import { type HandlerOptions, handlerOptions } from '../base';
 
-const TimeUnitsSchema = z.enum(['ms', 's', 'm', 'h', 'd', 'w', 'y']);
+// Docker's 'until' filter accepts Go duration strings: ns, us, ms, s, m, h
+const TimeUnitsSchema = z.enum(['ns', 'us', 'ms', 's', 'm', 'h']);
 const TimeStringSchema = z.templateLiteral([z.number(), TimeUnitsSchema]);
 
 const schema = z.object({
@@ -19,7 +20,11 @@ async function handler({ options, error: _error }: HandlerOptions<Options>) {
 
 export const command = new Command('cleanup')
   .description('Clean up old docker images, containers and networks.')
-  .option('--cutoff <duration>', 'Cutoff time for cleanup (e.g., 24h, 7d)', '24h')
+  .option(
+    '--cutoff <duration>',
+    'Cutoff time for cleanup. Accepts Go duration units: ns, us, ms, s, m, h (e.g., 24h, 30m)',
+    '24h',
+  )
   .action(
     async (...args) =>
       await handler(

--- a/packages/core/src/runner/cleanup.ts
+++ b/packages/core/src/runner/cleanup.ts
@@ -10,7 +10,7 @@ import { PROXY_IMAGE_NAME, digestName, hasDigest, repositoryName, updaterImages 
 // which were left behind by old versions or any jobs
 // which may have crashed before deleting their own containers or networks
 //
-// cutoff - a Go duration string to pass to the Docker API's 'until' argument, default '24h'
+// cutoff - a Go duration string (ns, us, ms, s, m, h) to pass to the Docker API's 'until' argument, default '24h'
 export async function cleanup(cutoff = '24h'): Promise<void> {
   if (process.env.DEPENDABOT_DISABLE_CLEANUP === '1') {
     return;


### PR DESCRIPTION
Previously the schema allowed `d`, `w`, and `y` which Docker's `until` filter does not accept, causing a 500 error at runtime.

Fixes: #2718 