### PR TITLE
Fix duplicate file changes in commit payload for uv ecosystem security updates

### DIFF
--- a/.changeset/green-numbers-fall.md
+++ b/.changeset/green-numbers-fall.md
@@ -1,0 +1,5 @@
+---
+"@paklo/core": patch
+---
+
+Fix duplicate file changes in commit payload for uv ecosystem security updates

--- a/packages/core/src/azure/client/wrapper.ts
+++ b/packages/core/src/azure/client/wrapper.ts
@@ -214,6 +214,7 @@ export class AzureDevOpsClientWrapper {
             author: options.author,
             changes: options.changes
               .filter((change) => change.changeType !== 'none')
+              .filter((change, index, self) => index === self.findLastIndex((c) => c.path === change.path))
               .map(({ changeType, ...change }) => {
                 return {
                   changeType,
@@ -394,6 +395,7 @@ export class AzureDevOpsClientWrapper {
             author: options.author,
             changes: options.changes
               .filter((change) => change.changeType !== 'none')
+              .filter((change, index, self) => index === self.findLastIndex((c) => c.path === change.path))
               .map(({ changeType, ...change }) => {
                 return {
                   changeType,


### PR DESCRIPTION
## Problem

When running security-only updates (`open-pull-requests-limit: 0`) for the `uv` package ecosystem,
the Azure DevOps API returns a `400 Bad Request` error with the following message:

> Multiple operations were attempted on file '/path/pyproject.toml' within the same request.
> Only a single operation may be applied to each file within the same commit.

## Root Cause

Security-only updates run two sequential Dependabot jobs:

1. A **discovery job** (`forDependenciesList`) to find all dependencies
2. An **update job** (`forUpdate`) to perform the actual update

Unlike `pip`/`poetry`, the `uv` resolver writes back `pyproject.toml` as a side effect of dependency
resolution during the discovery job. These file changes accumulate in the server state and leak into
the subsequent update job's commit payload, causing `pyproject.toml` to appear twice in the same
commit — which the Azure DevOps Git API does not allow.

This does not affect `poetry` or `pip` because their resolvers do not write back files during discovery.

## Fix

Added deduplication of file changes by path before constructing the Azure DevOps Git push payload
in `wrapper.ts`, in both `createPullRequest` and `updatePullRequest`. The last occurrence of each
file path is kept, ensuring the update job's version of the file takes precedence over any version
produced during the discovery job.

## Testing

Verified locally using `@paklo/cli` against an Azure DevOps repository configured with
`package-ecosystem: uv` and `open-pull-requests-limit: 0`.